### PR TITLE
Add PostgreSQL support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,7 @@
 - For every new provider added in the future, implement provider tests from the start.
 - New providers must include, at minimum, unit coverage for provider factory wiring, connection settings serialization, schema SQL, and completion/execution behavior where applicable.
 - When feasible, add opt-in integration tests for each new provider using real configured connections, following the same pattern used for SQL Server and MySQL.
+
+## Documentation
+- When adding a new database provider or significant provider capability, update `README.md` in the same branch.
+- Provider documentation updates must cover supported providers and any local setup needed to validate the new provider during development.

--- a/DataDeveloper.Data/DataDeveloper.Data.csproj
+++ b/DataDeveloper.Data/DataDeveloper.Data.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Dapper" Version="2.1.72" />
         <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
         <PackageReference Include="MySqlConnector" Version="2.4.0" />
+        <PackageReference Include="Npgsql" Version="8.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DataDeveloper.Data/JsonConverters/ConnectionSettingsConverter.cs
+++ b/DataDeveloper.Data/JsonConverters/ConnectionSettingsConverter.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Serialization;
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 
 namespace DataDeveloper.Data.JsonConverters;
@@ -21,6 +22,7 @@ public class ConnectionSettingsConverter : JsonConverter<ConnectionSettings>
         ConnectionSettings connection = type switch
         {
             DatabaseType.SqlServer => (ConnectionSettings?)JsonSerializer.Deserialize<SqlServerConnectionSettings>(json, options),
+            DatabaseType.PostgresSql => (ConnectionSettings?)JsonSerializer.Deserialize<PostgresConnectionSettings>(json, options),
             DatabaseType.MySql => (ConnectionSettings?)JsonSerializer.Deserialize<MySqlConnectionSettings>(json, options),
             _ => throw new NotSupportedException($"Tipo {type} não suportado.")
         } ?? throw new JsonException($"Could not deserialize connection settings for database type {type}.");

--- a/DataDeveloper.Data/Providers/PostgresSql/PostgresConnectionSettings.cs
+++ b/DataDeveloper.Data/Providers/PostgresSql/PostgresConnectionSettings.cs
@@ -1,0 +1,11 @@
+using DataDeveloper.Data.Models;
+using ReactiveUI.Fody.Helpers;
+
+namespace DataDeveloper.Data.Providers.PostgresSql;
+
+public class PostgresConnectionSettings : ConnectionSettings
+{
+    [Reactive] public string Server { get; set; } = string.Empty;
+    [Reactive] public string Database { get; set; } = string.Empty;
+    [Reactive] public int Port { get; set; } = 5432;
+}

--- a/DataDeveloper.Data/Providers/PostgresSql/PostgresDatabaseProvider.cs
+++ b/DataDeveloper.Data/Providers/PostgresSql/PostgresDatabaseProvider.cs
@@ -1,0 +1,133 @@
+using System.Data.Common;
+using System.Text;
+using DataDeveloper.Data.Services;
+using Npgsql;
+
+namespace DataDeveloper.Data.Providers.PostgresSql;
+
+public class PostgresDatabaseProvider : DatabaseProviderBase<PostgresConnectionSettings>
+{
+    public PostgresDatabaseProvider(PostgresConnectionSettings connectionSettings)
+        : base(connectionSettings)
+    {
+    }
+
+    public override DbConnection GetConnection()
+    {
+        var sslMode = ConnectionSettings.Encrypt
+            ? ConnectionSettings.TrustServerCertificate
+                ? SslMode.Require
+                : SslMode.VerifyCA
+            : SslMode.Disable;
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = ConnectionSettings.Server,
+            Database = ConnectionSettings.Database,
+            Username = ConnectionSettings.User,
+            Password = ConnectionSettings.Password,
+            Port = ConnectionSettings.Port,
+            SslMode = sslMode,
+            TrustServerCertificate = ConnectionSettings.TrustServerCertificate
+        };
+
+        return new NpgsqlConnection(connectionStringBuilder.ConnectionString);
+    }
+
+    public override string GetTableStatement()
+    {
+        return """
+               select table_name as Name
+               from information_schema.tables
+               where table_schema = current_schema()
+                 and table_type = 'BASE TABLE'
+               order by table_name;
+               """;
+    }
+
+    public override string GetViewStatement()
+    {
+        return """
+               select table_name as Name
+               from information_schema.views
+               where table_schema = current_schema()
+               order by table_name;
+               """;
+    }
+
+    public override string GetColumnStatement()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("select");
+        sb.AppendLine("    c.column_name as \"Name\",");
+        sb.AppendLine("    c.data_type as \"DataType\",");
+        sb.AppendLine("    coalesce(c.character_maximum_length, 0) as \"Length\",");
+        sb.AppendLine("    coalesce(c.numeric_precision, 0) as \"Precision\",");
+        sb.AppendLine("    coalesce(c.numeric_scale, 0) as \"Scale\",");
+        sb.AppendLine("    case when c.is_nullable = 'YES' then true else false end as \"IsNullable\",");
+        sb.AppendLine("    case when k.column_name is not null then true else false end as \"IsPrimaryKey\"");
+        sb.AppendLine("from information_schema.columns c");
+        sb.AppendLine("left join information_schema.key_column_usage k");
+        sb.AppendLine("    on k.table_schema = c.table_schema");
+        sb.AppendLine("   and k.table_name = c.table_name");
+        sb.AppendLine("   and k.column_name = c.column_name");
+        sb.AppendLine("left join information_schema.table_constraints tc");
+        sb.AppendLine("    on tc.constraint_schema = k.constraint_schema");
+        sb.AppendLine("   and tc.constraint_name = k.constraint_name");
+        sb.AppendLine("   and tc.table_name = k.table_name");
+        sb.AppendLine("   and tc.constraint_type = 'PRIMARY KEY'");
+        sb.AppendLine("where c.table_schema = current_schema()");
+        sb.AppendLine("  and c.table_name = @TableName");
+        sb.AppendLine("  and (k.column_name is null or tc.constraint_name is not null)");
+        sb.AppendLine("order by c.ordinal_position;");
+
+        return sb.ToString();
+    }
+
+    public override string GetProcedureStatement()
+    {
+        return """
+               select
+                   routine_name as Name,
+                   specific_name as SpecificName
+               from information_schema.routines
+               where specific_schema = current_schema()
+                 and routine_type = 'PROCEDURE'
+               order by routine_name;
+               """;
+    }
+
+    public override string GetFunctionStatement()
+    {
+        return """
+               select
+                   routine_name as Name,
+                   specific_name as SpecificName,
+                   data_type as DataType
+               from information_schema.routines
+               where specific_schema = current_schema()
+                 and routine_type = 'FUNCTION'
+               order by routine_name;
+               """;
+    }
+
+    public override string GetRoutineParameterStatement()
+    {
+        return """
+               select
+                   coalesce(parameter_name, 'return') as Name,
+                   data_type as DataType,
+                   coalesce(character_maximum_length, 0) as Length,
+                   coalesce(numeric_precision, 0) as Precision,
+                   coalesce(numeric_scale, 0) as Scale,
+                   case when is_nullable = 'YES' then true else false end as IsNullable,
+                   parameter_mode as Mode,
+                   ordinal_position as Position
+               from information_schema.parameters
+               where specific_schema = current_schema()
+                 and specific_name = @SpecificName
+               order by ordinal_position;
+               """;
+    }
+}

--- a/DataDeveloper.Data/Services/DatabaseProviderFactoryService.cs
+++ b/DataDeveloper.Data/Services/DatabaseProviderFactoryService.cs
@@ -1,6 +1,7 @@
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Interfaces;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 
 namespace DataDeveloper.Data.Services;
@@ -12,6 +13,7 @@ public class DatabaseProviderFactoryService
         return connectionSettings.DatabaseType switch
         {
             DatabaseType.SqlServer => new SqlServerDatabaseProvider((SqlServerConnectionSettings)connectionSettings),
+            DatabaseType.PostgresSql => new PostgresDatabaseProvider((PostgresConnectionSettings)connectionSettings),
             DatabaseType.MySql => new MySqlDatabaseProvider((MySqlConnectionSettings)connectionSettings),
             _ => throw new NotImplementedException($"Database type {connectionSettings.DatabaseType} is not implemented")
         };

--- a/DataDeveloper.Tests/DatabaseObjectScriptBuilderTests.cs
+++ b/DataDeveloper.Tests/DatabaseObjectScriptBuilderTests.cs
@@ -2,6 +2,7 @@ using System;
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 using DataDeveloper.Services;
 using Xunit;
@@ -36,6 +37,19 @@ public class DatabaseObjectScriptBuilderTests
     }
 
     [Fact]
+    public void BuildSelectRowsScript_UsesPostgresLimitSyntax()
+    {
+        var node = CreateNode(NodeType.Table, "public.orders");
+        var settings = new PostgresConnectionSettings { DatabaseType = DatabaseType.PostgresSql };
+
+        var script = DatabaseObjectScriptBuilder.BuildSelectRowsScript(settings, node);
+
+        Assert.Contains("select *", script, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("from \"public\".\"orders\"", script, System.StringComparison.Ordinal);
+        Assert.Contains("limit 100;", script, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void BuildExecuteProcedureScript_UsesProviderSpecificSyntax()
     {
         var procedureNode = CreateNode(NodeType.Procedure, "ProcessOrders");
@@ -65,9 +79,13 @@ public class DatabaseObjectScriptBuilderTests
         var mySqlScript = DatabaseObjectScriptBuilder.BuildExecuteProcedureScript(
             new MySqlConnectionSettings { DatabaseType = DatabaseType.MySql },
             procedureNode);
+        var postgresScript = DatabaseObjectScriptBuilder.BuildExecuteProcedureScript(
+            new PostgresConnectionSettings { DatabaseType = DatabaseType.PostgresSql },
+            procedureNode);
 
         Assert.Equal("exec [ProcessOrders] @id = @id, @result = @result output;", sqlServerScript);
         Assert.Equal("call `ProcessOrders`(@id, @result);", mySqlScript);
+        Assert.Equal("call \"ProcessOrders\"(@id, @result);", postgresScript);
     }
 
     [Fact]
@@ -106,6 +124,18 @@ public class DatabaseObjectScriptBuilderTests
             functionNode);
 
         Assert.Equal("select [dbo].[CalculateTax](@amount, @region);", script);
+    }
+
+    [Fact]
+    public void BuildQualifiedName_QuotesPostgresIdentifiers()
+    {
+        var tableNode = CreateNode(NodeType.Table, "public.Order Details");
+
+        var qualifiedName = DatabaseObjectScriptBuilder.BuildQualifiedName(
+            new PostgresConnectionSettings { DatabaseType = DatabaseType.PostgresSql },
+            tableNode);
+
+        Assert.Equal("\"public\".\"Order Details\"", qualifiedName);
     }
 
     private static SchemaNode CreateNode(NodeType nodeType, string name, bool isFolder = false, SchemaNode? parent = null, object? tag = null)

--- a/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
+++ b/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
@@ -4,6 +4,7 @@ using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.JsonConverters;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 using Xunit;
 
@@ -66,6 +67,31 @@ public class ConnectionSettingsConverterTests
     }
 
     [Fact]
+    public void Deserialize_ReturnsPostgresConnectionSettings_ForPostgresPayload()
+    {
+        const string json = """
+                            {
+                              "Id":"25222222-2222-2222-2222-222222222222",
+                              "Name":"Postgres",
+                              "DatabaseType":"PostgresSql",
+                              "Server":"localhost",
+                              "Database":"app",
+                              "User":"postgres",
+                              "Password":"pwd",
+                              "Port":5433,
+                              "Encrypt":true,
+                              "TrustServerCertificate":false
+                            }
+                            """;
+
+        var connection = JsonSerializer.Deserialize<ConnectionSettings>(json, SerializerOptions);
+
+        var typed = Assert.IsType<PostgresConnectionSettings>(connection);
+        Assert.Equal(DatabaseType.PostgresSql, typed.DatabaseType);
+        Assert.Equal(5433, typed.Port);
+    }
+
+    [Fact]
     public void Serialize_RoundTripsSqlServerConnectionSettings()
     {
         ConnectionSettings connection = new SqlServerConnectionSettings
@@ -112,5 +138,30 @@ public class ConnectionSettingsConverterTests
         var typed = Assert.IsType<MySqlConnectionSettings>(deserialized);
         Assert.Equal((uint)3306, typed.Port);
         Assert.Equal(DatabaseType.MySql, typed.DatabaseType);
+    }
+
+    [Fact]
+    public void Serialize_RoundTripsPostgresConnectionSettings()
+    {
+        ConnectionSettings connection = new PostgresConnectionSettings
+        {
+            Id = Guid.Parse("54444444-4444-4444-4444-444444444444"),
+            Name = "Postgres",
+            DatabaseType = DatabaseType.PostgresSql,
+            Server = "localhost",
+            Database = "app",
+            User = "postgres",
+            Password = "pwd",
+            Port = 5432,
+            Encrypt = true,
+            TrustServerCertificate = false
+        };
+
+        var json = JsonSerializer.Serialize(connection, SerializerOptions);
+        var deserialized = JsonSerializer.Deserialize<ConnectionSettings>(json, SerializerOptions);
+
+        var typed = Assert.IsType<PostgresConnectionSettings>(deserialized);
+        Assert.Equal(5432, typed.Port);
+        Assert.Equal(DatabaseType.PostgresSql, typed.DatabaseType);
     }
 }

--- a/DataDeveloper.Tests/Providers/DatabaseProviderFactoryServiceTests.cs
+++ b/DataDeveloper.Tests/Providers/DatabaseProviderFactoryServiceTests.cs
@@ -1,6 +1,7 @@
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Interfaces;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 using DataDeveloper.Data.Services;
 using Xunit;
@@ -42,6 +43,22 @@ public class DatabaseProviderFactoryServiceTests
     }
 
     [Fact]
+    public void GetDatabaseProvider_ReturnsPostgresProvider_ForPostgresConnection()
+    {
+        var factory = new DatabaseProviderFactoryService();
+        var connection = new PostgresConnectionSettings
+        {
+            DatabaseType = DatabaseType.PostgresSql,
+            Server = "localhost",
+            Database = "app"
+        };
+
+        var provider = factory.GetDatabaseProvider(connection);
+
+        Assert.IsType<PostgresDatabaseProvider>(provider);
+    }
+
+    [Fact]
     public void GetSchemaExplorer_ReturnsExplorer_ForSqlServerConnection()
     {
         var factory = new DatabaseProviderFactoryService();
@@ -64,6 +81,22 @@ public class DatabaseProviderFactoryServiceTests
         IConnectionSettings connection = new MySqlConnectionSettings
         {
             DatabaseType = DatabaseType.MySql,
+            Server = "localhost",
+            Database = "app"
+        };
+
+        var explorer = factory.GetSchemaExplorer(connection);
+
+        Assert.NotNull(explorer);
+    }
+
+    [Fact]
+    public void GetSchemaExplorer_ReturnsExplorer_ForPostgresConnection()
+    {
+        var factory = new DatabaseProviderFactoryService();
+        IConnectionSettings connection = new PostgresConnectionSettings
+        {
+            DatabaseType = DatabaseType.PostgresSql,
             Server = "localhost",
             Database = "app"
         };

--- a/DataDeveloper.Tests/Providers/PostgresDatabaseProviderTests.cs
+++ b/DataDeveloper.Tests/Providers/PostgresDatabaseProviderTests.cs
@@ -1,0 +1,105 @@
+using DataDeveloper.Data.Providers.PostgresSql;
+using Npgsql;
+using Xunit;
+
+namespace DataDeveloper.Tests.Providers;
+
+public class PostgresDatabaseProviderTests
+{
+    [Fact]
+    public void GetConnection_ReturnsNpgsqlConnection()
+    {
+        var provider = new PostgresDatabaseProvider(new PostgresConnectionSettings
+        {
+            Server = "localhost",
+            Database = "app",
+            User = "postgres",
+            Password = "pwd",
+            Port = 5433,
+            Encrypt = false,
+            TrustServerCertificate = false
+        });
+
+        var connection = provider.GetConnection();
+
+        var npgsqlConnection = Assert.IsType<NpgsqlConnection>(connection);
+        var builder = new NpgsqlConnectionStringBuilder(npgsqlConnection.ConnectionString);
+        Assert.Equal("localhost", builder.Host);
+        Assert.Equal("app", builder.Database);
+        Assert.Equal("postgres", builder.Username);
+        Assert.Equal(5433, builder.Port);
+        Assert.Equal(SslMode.Disable, builder.SslMode);
+    }
+
+    [Fact]
+    public void GetTableStatement_UsesInformationSchemaTables()
+    {
+        var provider = new PostgresDatabaseProvider(new PostgresConnectionSettings());
+
+        var sql = provider.GetTableStatement();
+
+        Assert.Contains("information_schema.tables", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("table_schema = current_schema()", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("table_type = 'BASE TABLE'", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetColumnStatement_UsesInformationSchemaColumns()
+    {
+        var provider = new PostgresDatabaseProvider(new PostgresConnectionSettings());
+
+        var sql = provider.GetColumnStatement();
+
+        Assert.Contains("information_schema.columns", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("information_schema.key_column_usage", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("information_schema.table_constraints", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("table_name = @TableName", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetViewStatement_UsesInformationSchemaViews()
+    {
+        var provider = new PostgresDatabaseProvider(new PostgresConnectionSettings());
+
+        var sql = provider.GetViewStatement();
+
+        Assert.Contains("information_schema.views", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("table_schema = current_schema()", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetProcedureStatement_UsesInformationSchemaRoutines()
+    {
+        var provider = new PostgresDatabaseProvider(new PostgresConnectionSettings());
+
+        var sql = provider.GetProcedureStatement();
+
+        Assert.Contains("information_schema.routines", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("routine_type = 'PROCEDURE'", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("specific_schema = current_schema()", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetFunctionStatement_UsesInformationSchemaRoutines()
+    {
+        var provider = new PostgresDatabaseProvider(new PostgresConnectionSettings());
+
+        var sql = provider.GetFunctionStatement();
+
+        Assert.Contains("information_schema.routines", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("routine_type = 'FUNCTION'", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("specific_schema = current_schema()", sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetRoutineParameterStatement_UsesInformationSchemaParameters()
+    {
+        var provider = new PostgresDatabaseProvider(new PostgresConnectionSettings());
+
+        var sql = provider.GetRoutineParameterStatement();
+
+        Assert.Contains("information_schema.parameters", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("specific_name = @SpecificName", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("specific_schema = current_schema()", sql, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DataDeveloper.Tests/SqlCompletionProviderTests.cs
+++ b/DataDeveloper.Tests/SqlCompletionProviderTests.cs
@@ -178,6 +178,43 @@ public class SqlCompletionProviderTests
     }
 
     [Fact]
+    public void ManualRequest_AfterPostgresQuotedAliasDot_ReturnsColumnsTrigger()
+    {
+        var sql = "select \"c\".";
+        var caretOffset = sql.Length;
+
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, caretOffset);
+
+        Assert.Equal(CompletionTrigger.Columns, request.Context.Trigger);
+        Assert.Equal("c", request.Context.ObjectNameBeforeDot);
+    }
+
+    [Fact]
+    public void AutoRequest_InsertIntoPostgresQuotedTable_OpenParen_ReturnsColumnsTrigger()
+    {
+        var sql = "insert into \"clientes\" (";
+
+        var request = SqlCompletionProvider.GetAutoCompletionRequest(sql, sql.Length, "(");
+
+        Assert.NotNull(request);
+        Assert.True(request!.Context.IsInsideInsertColumnList);
+        Assert.Equal(CompletionTrigger.Columns, request.Context.Trigger);
+        Assert.Equal("clientes", request.Context.TargetTableName);
+    }
+
+    [Fact]
+    public void ManualRequest_AfterPostgresQuotedUpdateSet_ReturnsColumnsTrigger()
+    {
+        var sql = "update \"clientes\" set ";
+
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, sql.Length);
+
+        Assert.Equal(CompletionTrigger.Columns, request.Context.Trigger);
+        Assert.Equal(SqlCompletionProvider.SqlClause.Set, request.Context.Clause);
+        Assert.Equal("clientes", request.Context.TargetTableName);
+    }
+
+    [Fact]
     public async Task GetCompletionsAsync_ReturnsColumns_ForSqlServerAliasWithSeededSchemaCache()
     {
         var connection = new TestConnectionSettings { DatabaseType = DatabaseType.SqlServer };
@@ -207,6 +244,21 @@ public class SqlCompletionProviderTests
         Assert.Contains(completions, item => item.Text == "nome");
     }
 
+    [Fact]
+    public async Task GetCompletionsAsync_ReturnsColumns_ForPostgresQuotedAliasWithSeededSchemaCache()
+    {
+        var connection = new TestConnectionSettings { DatabaseType = DatabaseType.PostgresSql };
+        SeedSchemaCache(connection.Id, "clientes", "id", "nome");
+
+        var sql = "select \"c\". from \"clientes\" as \"c\"";
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, "select \"c\".".Length);
+
+        var completions = await SqlCompletionProvider.GetCompletionsAsync(connection, sql, "select \"c\".".Length, request);
+
+        Assert.Contains(completions, item => item.Text == "id");
+        Assert.Contains(completions, item => item.Text == "nome");
+    }
+
     private static void SeedSchemaCache(Guid connectionId, string tableName, params string[] columns)
     {
         var providerType = typeof(SqlCompletionProvider);
@@ -228,6 +280,7 @@ public class SqlCompletionProviderTests
         tableNodes[tableName] = schemaNode;
         tableNodes[$"[{tableName}]"] = schemaNode;
         tableNodes[$"`{tableName}`"] = schemaNode;
+        tableNodes[$"\"{tableName}\""] = schemaNode;
 
         var columnsByTable = (IDictionary)cacheType.GetProperty("ColumnsByTable")!.GetValue(cache)!;
         columnsByTable[tableName] = columns;

--- a/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
+++ b/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
@@ -1,6 +1,7 @@
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 using DataDeveloper.Interfaces;
 using DataDeveloper.Services;
@@ -106,6 +107,39 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(mySql.Port, loadedMySql.Port);
         repository.LoadPassword(loadedMySql);
         Assert.Equal(mySql.Password, loadedMySql.Password);
+    }
+
+    [Fact]
+    public void SaveAll_AndLoadAll_RoundTripsPostgresConnection()
+    {
+        var secretStore = new InMemorySecretStore();
+        var repository = CreateRepository(secretStore: secretStore);
+        var postgres = new PostgresConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            CredentialId = Guid.NewGuid(),
+            Name = "Postgres",
+            DatabaseType = DatabaseType.PostgresSql,
+            Server = "postgres.local",
+            Database = "app",
+            Port = 5433,
+            User = "postgres",
+            Password = "postgres-secret",
+            Encrypt = true,
+            TrustServerCertificate = false
+        };
+
+        repository.SaveAll([postgres]);
+
+        var loaded = repository.LoadAll();
+
+        var loadedPostgres = Assert.IsType<PostgresConnectionSettings>(Assert.Single(loaded));
+        Assert.Equal(postgres.CredentialId, loadedPostgres.CredentialId);
+        Assert.Equal(postgres.Server, loadedPostgres.Server);
+        Assert.Equal(postgres.Database, loadedPostgres.Database);
+        Assert.Equal(postgres.Port, loadedPostgres.Port);
+        repository.LoadPassword(loadedPostgres);
+        Assert.Equal(postgres.Password, loadedPostgres.Password);
     }
 
     [Fact]

--- a/DataDeveloper/Converters/EnumValueToStringConverter.cs
+++ b/DataDeveloper/Converters/EnumValueToStringConverter.cs
@@ -9,6 +9,8 @@ public class EnumValueToResourceConverter : IValueConverter
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         var valueText = value?.ToString()?.ToLowerInvariant() ?? string.Empty;
+        if (string.Equals(valueText, "postgressql", StringComparison.Ordinal))
+            valueText = "postgresql";
         var result = $"/Assets/Svg/{valueText}.svg";
         return result;
     }

--- a/DataDeveloper/Services/DatabaseObjectScriptBuilder.cs
+++ b/DataDeveloper/Services/DatabaseObjectScriptBuilder.cs
@@ -27,6 +27,7 @@ public static class DatabaseObjectScriptBuilder
         return connectionSettings.DatabaseType switch
         {
             DatabaseType.SqlServer => $"select top 100 *{Environment.NewLine}from {qualifiedName};",
+            DatabaseType.PostgresSql => $"select *{Environment.NewLine}from {qualifiedName}{Environment.NewLine}limit 100;",
             DatabaseType.MySql => $"select *{Environment.NewLine}from {qualifiedName}{Environment.NewLine}limit 100;",
             _ => $"select *{Environment.NewLine}from {qualifiedName};"
         };
@@ -45,6 +46,7 @@ public static class DatabaseObjectScriptBuilder
         return connectionSettings.DatabaseType switch
         {
             DatabaseType.SqlServer => BuildSqlServerProcedureScript(qualifiedName, parameters),
+            DatabaseType.PostgresSql => BuildPostgresProcedureScript(qualifiedName, parameters),
             DatabaseType.MySql => BuildMySqlProcedureScript(qualifiedName, parameters),
             _ => qualifiedName
         };
@@ -95,6 +97,7 @@ public static class DatabaseObjectScriptBuilder
         return connectionSettings.DatabaseType switch
         {
             DatabaseType.SqlServer => $"[{identifier.Replace("]", "]]", StringComparison.Ordinal)}]",
+            DatabaseType.PostgresSql => $"\"{identifier.Replace("\"", "\"\"", StringComparison.Ordinal)}\"",
             DatabaseType.MySql => $"`{identifier.Replace("`", "``", StringComparison.Ordinal)}`",
             _ => identifier
         };
@@ -142,6 +145,12 @@ public static class DatabaseObjectScriptBuilder
     }
 
     private static string BuildMySqlProcedureScript(string qualifiedName, IReadOnlyList<RoutineParameterModel> parameters)
+    {
+        var argumentList = string.Join(", ", parameters.Select(parameter => parameter.Name));
+        return $"call {qualifiedName}({argumentList});";
+    }
+
+    private static string BuildPostgresProcedureScript(string qualifiedName, IReadOnlyList<RoutineParameterModel> parameters)
     {
         var argumentList = string.Join(", ", parameters.Select(parameter => parameter.Name));
         return $"call {qualifiedName}({argumentList});";

--- a/DataDeveloper/Services/SqlCompletionProvider.cs
+++ b/DataDeveloper/Services/SqlCompletionProvider.cs
@@ -16,7 +16,7 @@ namespace DataDeveloper.Services;
 
 public static class SqlCompletionProvider
 {
-    private const string IdentifierPattern = @"(?:\[[^\]]+\]|`[^`]+`|[A-Za-z_][A-Za-z0-9_]*)";
+    private const string IdentifierPattern = @"(?:\[[^\]]+\]|`[^`]+`|""[^""]+""|[A-Za-z_][A-Za-z0-9_]*)";
 
     private static readonly Regex AliasRegex = new(
         $@"(?ix)
@@ -191,6 +191,7 @@ public static class SqlCompletionProvider
             cache.TableNodes[tableNode.Name] = tableNode;
             cache.TableNodes[$"[{tableNode.Name}]"] = tableNode;
             cache.TableNodes[$"`{tableNode.Name}`"] = tableNode;
+            cache.TableNodes[$"\"{tableNode.Name}\""] = tableNode;
         }
 
         cache.TablesLoaded = true;
@@ -306,7 +307,7 @@ public static class SqlCompletionProvider
             return null;
 
         var index = caretOffset - 1;
-        while (index >= 0 && (char.IsLetterOrDigit(editorText[index]) || editorText[index] == '_' || editorText[index] == ']' || editorText[index] == '`'))
+        while (index >= 0 && IsIdentifierCharacter(editorText[index], allowClosingQuoteOnly: true))
             index--;
 
         if (index < 0 || editorText[index] != '.')
@@ -314,7 +315,7 @@ public static class SqlCompletionProvider
 
         var end = index;
         index--;
-        while (index >= 0 && (char.IsLetterOrDigit(editorText[index]) || editorText[index] == '_' || editorText[index] == '[' || editorText[index] == ']' || editorText[index] == '`'))
+        while (index >= 0 && IsIdentifierCharacter(editorText[index], allowClosingQuoteOnly: false))
             index--;
 
         var objectName = editorText[(index + 1)..end];
@@ -511,7 +512,18 @@ public static class SqlCompletionProvider
 
     private static string NormalizeIdentifier(string value)
     {
-        return value.Trim().Trim('[', ']', '`');
+        return value.Trim().Trim('[', ']', '`', '"');
+    }
+
+    private static bool IsIdentifierCharacter(char ch, bool allowClosingQuoteOnly)
+    {
+        return char.IsLetterOrDigit(ch) ||
+               ch == '_' ||
+               ch == '[' ||
+               ch == ']' ||
+               ch == '`' ||
+               ch == '"' ||
+               (!allowClosingQuoteOnly && ch == '.');
     }
 
     private static string[] ParseExplicitCteColumns(string columnsValue)

--- a/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
+++ b/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
@@ -6,6 +6,7 @@ using DataDeveloper.Core;
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 using DataDeveloper.Interfaces;
 using Microsoft.Data.Sqlite;
@@ -83,6 +84,11 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                     mySql.Server = reader.GetString(reader.GetOrdinal("server"));
                     mySql.Database = reader.GetString(reader.GetOrdinal("database_name"));
                     mySql.Port = reader.IsDBNull(reader.GetOrdinal("port")) ? 3306u : Convert.ToUInt32(reader.GetInt64(reader.GetOrdinal("port")));
+                    break;
+                case PostgresConnectionSettings postgres:
+                    postgres.Server = reader.GetString(reader.GetOrdinal("server"));
+                    postgres.Database = reader.GetString(reader.GetOrdinal("database_name"));
+                    postgres.Port = reader.IsDBNull(reader.GetOrdinal("port")) ? 5432 : Convert.ToInt32(reader.GetInt64(reader.GetOrdinal("port")));
                     break;
             }
 
@@ -359,6 +365,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         return databaseType switch
         {
             DatabaseType.SqlServer => new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            DatabaseType.PostgresSql => new PostgresConnectionSettings { DatabaseType = DatabaseType.PostgresSql },
             DatabaseType.MySql => new MySqlConnectionSettings { DatabaseType = DatabaseType.MySql },
             _ => throw new NotSupportedException($"Database type {databaseType} is not supported.")
         };
@@ -386,6 +393,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         connectionSettings switch
         {
             SqlServerConnectionSettings sqlServer => sqlServer.Server,
+            PostgresConnectionSettings postgres => postgres.Server,
             MySqlConnectionSettings mySql => mySql.Server,
             _ => string.Empty
         };
@@ -394,6 +402,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         connectionSettings switch
         {
             SqlServerConnectionSettings sqlServer => sqlServer.Database,
+            PostgresConnectionSettings postgres => postgres.Database,
             MySqlConnectionSettings mySql => mySql.Database,
             _ => string.Empty
         };
@@ -401,6 +410,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
     private static object GetPort(ConnectionSettings connectionSettings) =>
         connectionSettings switch
         {
+            PostgresConnectionSettings postgres => postgres.Port,
             MySqlConnectionSettings mySql => (long)mySql.Port,
             _ => DBNull.Value
         };

--- a/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
+++ b/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
@@ -12,6 +12,7 @@ using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Interfaces;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Data.Providers.MySql;
+using DataDeveloper.Data.Providers.PostgresSql;
 using DataDeveloper.Data.Providers.SqlServer;
 using DataDeveloper.Data.Services;
 using DataDeveloper.Enums;
@@ -84,6 +85,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
         ConnectionSettings? duplicate = SelectedConnection.DatabaseType switch
         {
             DatabaseType.SqlServer => (ConnectionSettings?)SelectedConnection.Map<SqlServerConnectionSettings>(),
+            DatabaseType.PostgresSql => (ConnectionSettings?)SelectedConnection.Map<PostgresConnectionSettings>(),
             DatabaseType.MySql => (ConnectionSettings?)SelectedConnection.Map<MySqlConnectionSettings>(),
             _ => null
         };
@@ -145,7 +147,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
     }
 
     public ObservableCollection<ConnectionSettings> Connections { get; private set; } = new();
-    public IReadOnlyList<DatabaseType> AvailableDatabaseTypes { get; } = [DatabaseType.SqlServer, DatabaseType.MySql];
+    public IReadOnlyList<DatabaseType> AvailableDatabaseTypes { get; } = [DatabaseType.SqlServer, DatabaseType.PostgresSql, DatabaseType.MySql];
 
     private ConnectionSettings? _selectedConnection;
     public ConnectionSettings? SelectedConnection
@@ -157,7 +159,9 @@ public class ConnectionSelectorViewModel : ViewModelBase
             if (value is not null)
                 SelectedDatabaseType = value.DatabaseType;
             this.RaisePropertyChanged(nameof(IsMySqlConnectionSelected));
+            this.RaisePropertyChanged(nameof(IsPostgresConnectionSelected));
             this.RaisePropertyChanged(nameof(IsSqlServerConnectionSelected));
+            this.RaisePropertyChanged(nameof(IsPortConnectionSelected));
         }
     }
 
@@ -176,7 +180,10 @@ public class ConnectionSelectorViewModel : ViewModelBase
     }    
 
     public bool IsMySqlConnectionSelected => SelectedConnection?.DatabaseType == DatabaseType.MySql;
+    public bool IsPostgresConnectionSelected => SelectedConnection?.DatabaseType == DatabaseType.PostgresSql;
     public bool IsSqlServerConnectionSelected => SelectedConnection?.DatabaseType == DatabaseType.SqlServer;
+    public bool IsPortConnectionSelected =>
+        SelectedConnection?.DatabaseType is DatabaseType.MySql or DatabaseType.PostgresSql;
     public bool IsSecureStorageUnavailable => !_secretStore.IsAvailable;
     public string SecureStorageWarningMessage => _secretStore.UnavailableReason ?? string.Empty;
     
@@ -266,6 +273,19 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Encrypt = true,
                 TrustServerCertificate = false,
                 DatabaseType = DatabaseType.SqlServer
+            },
+            DatabaseType.PostgresSql => new PostgresConnectionSettings
+            {
+                Id = Guid.NewGuid(),
+                Name = "New PostgreSQL connection",
+                Server = "",
+                Database = "",
+                User = "",
+                Password = "",
+                Port = 5432,
+                Encrypt = false,
+                TrustServerCertificate = false,
+                DatabaseType = DatabaseType.PostgresSql
             },
             DatabaseType.MySql => new MySqlConnectionSettings
             {

--- a/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
+++ b/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
@@ -94,7 +94,7 @@
                     IsReadOnly="{Binding !IsEditing}" />
 
                 <Grid RowDefinitions="Auto,Auto"
-                      IsVisible="{Binding IsMySqlConnectionSelected}">
+                      IsVisible="{Binding IsPortConnectionSelected}">
                     <TextBlock Grid.Row="0" Text="Port" />
                     <TextBox Grid.Row="1"
                              Text="{Binding SelectedConnection.Port, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -140,6 +140,12 @@
                            Foreground="DarkGoldenrod"
                            TextWrapping="Wrap"
                            IsVisible="{Binding IsMySqlConnectionSelected}" />
+
+                <TextBlock Text="For PostgreSQL, use 'Encrypt connection' to enable SSL/TLS. 'Trust server certificate' skips certificate validation."
+                           FontSize="11"
+                           Foreground="DarkGoldenrod"
+                           TextWrapping="Wrap"
+                           IsVisible="{Binding IsPostgresConnectionSelected}" />
 
                 <TextBlock Text="{Binding SecureStorageWarningMessage}"
                            FontSize="11"

--- a/README.md
+++ b/README.md
@@ -20,28 +20,6 @@ DataDeveloper currently supports SQL Server, MySQL, and PostgreSQL, with provide
 - Track query execution and previous-result cleanup from the status bar
 - Run on macOS, Windows, and Linux
 
-## Local PostgreSQL
-
-Run a local PostgreSQL instance with Docker:
-
-```bash
-docker run --name datadeveloper-postgres \
-  -e POSTGRES_USER=datadeveloper \
-  -e POSTGRES_PASSWORD=datadeveloper \
-  -e POSTGRES_DB=datadeveloper \
-  -p 5432:5432 \
-  -v postgres_data:/var/lib/postgresql/data \
-  -d postgres:16
-```
-
-Connection defaults:
-
-- Server: `localhost`
-- Database: `datadeveloper`
-- User: `datadeveloper`
-- Password: `datadeveloper`
-- Port: `5432`
-
 ## Releases
 
 - GitHub Releases: https://github.com/NelsonSantos/DataDeveloper/releases

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # DataDeveloper
 A desktop SQL workspace focused on database exploration, query authoring, and result analysis.
 
-DataDeveloper currently supports SQL Server and MySQL, with provider-aware behavior across connection management, schema browsing, SQL completion, query execution, and result visualization.
+DataDeveloper currently supports SQL Server, MySQL, and PostgreSQL, with provider-aware behavior across connection management, schema browsing, SQL completion, query execution, and result visualization.
 
 ## Features
 
-- Manage saved database connections for SQL Server and MySQL
+- Manage saved database connections for SQL Server, MySQL, and PostgreSQL
 - Store saved connections in a local app-state database
 - Store connection credentials using the operating system secure storage
 - Browse database schema from a dedicated explorer panel
@@ -19,6 +19,28 @@ DataDeveloper currently supports SQL Server and MySQL, with provider-aware behav
 - Resize columns and navigate results with keyboard shortcuts
 - Track query execution and previous-result cleanup from the status bar
 - Run on macOS, Windows, and Linux
+
+## Local PostgreSQL
+
+Run a local PostgreSQL instance with Docker:
+
+```bash
+docker run --name datadeveloper-postgres \
+  -e POSTGRES_USER=datadeveloper \
+  -e POSTGRES_PASSWORD=datadeveloper \
+  -e POSTGRES_DB=datadeveloper \
+  -p 5432:5432 \
+  -v postgres_data:/var/lib/postgresql/data \
+  -d postgres:16
+```
+
+Connection defaults:
+
+- Server: `localhost`
+- Database: `datadeveloper`
+- User: `datadeveloper`
+- Password: `datadeveloper`
+- Port: `5432`
 
 ## Releases
 


### PR DESCRIPTION
## Summary
- add PostgreSQL provider support across connection management, schema explorer, persistence, and script generation
- add PostgreSQL-aware completion handling for quoted identifiers
- update README and AGENTS guidance for provider documentation

## Validation
- dotnet test DataDeveloper.Tests/DataDeveloper.Tests.csproj