### PR TITLE
Fix release workflow trigger fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: release-${{ github.event_name == 'push' && github.ref_name || format('v{0}', inputs.version) }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 
@@ -29,6 +33,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
       create_release: ${{ steps.version.outputs.create_release }}
+      checkout_ref: ${{ steps.version.outputs.checkout_ref }}
     steps:
       - id: version
         shell: bash
@@ -37,14 +42,17 @@ jobs:
             TAG="${GITHUB_REF_NAME}"
             VERSION="${TAG#v}"
             CREATE_RELEASE="true"
+            CHECKOUT_REF="${TAG}"
           else
             VERSION="${{ inputs.version }}"
             TAG="v${VERSION}"
             CREATE_RELEASE="${{ inputs.create_release }}"
+            CHECKOUT_REF="${TAG}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "create_release=$CREATE_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=$CHECKOUT_REF" >> "$GITHUB_OUTPUT"
 
   build-macos:
     needs: resolve-version
@@ -55,6 +63,8 @@ jobs:
         rid: [osx-x64, osx-arm64]
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve-version.outputs.checkout_ref }}
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
@@ -74,6 +84,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve-version.outputs.checkout_ref }}
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
@@ -105,6 +117,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.resolve-version.outputs.checkout_ref }}
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -32,6 +32,7 @@ NOTES_FILE="$2"
 TAG="v${VERSION}"
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-120}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
+TRIGGER_GRACE_ATTEMPTS="${TRIGGER_GRACE_ATTEMPTS:-4}"
 
 if [[ ! -f "$NOTES_FILE" ]]; then
   echo "Notes file not found: $NOTES_FILE" >&2
@@ -64,6 +65,36 @@ git tag -a "$TAG" -m "$TAG"
 
 echo "Pushing tag $TAG"
 git push origin "$TAG"
+
+find_release_run_id() {
+  gh run list --workflow release.yml --limit 20 --json databaseId,displayTitle,event \
+    --jq ".[] | select(.displayTitle == \"$TAG\" and .event == \"push\") | .databaseId" \
+    | head -n 1
+}
+
+echo "Checking whether the tag push triggered the Release workflow"
+RUN_ID=""
+for ((attempt=1; attempt<=TRIGGER_GRACE_ATTEMPTS; attempt++)); do
+  if gh release view "$TAG" >/dev/null 2>&1; then
+    echo "Release found. Updating notes from $NOTES_FILE"
+    gh release edit "$TAG" --title "$TAG" --notes-file "$NOTES_FILE"
+    echo "Release $TAG updated successfully."
+    exit 0
+  fi
+
+  RUN_ID="$(find_release_run_id || true)"
+  if [[ -n "$RUN_ID" ]]; then
+    echo "Detected Release workflow run $RUN_ID from tag push."
+    break
+  fi
+
+  sleep "$SLEEP_SECONDS"
+done
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "Tag push did not trigger Release automatically. Dispatching workflow manually."
+  gh workflow run release.yml -f version="$VERSION" -f create_release=true
+fi
 
 echo "Waiting for GitHub Release $TAG to be created by Actions"
 for ((attempt=1; attempt<=MAX_ATTEMPTS; attempt++)); do


### PR DESCRIPTION
## Summary
- make create-release.sh fall back to workflow_dispatch when tag pushes do not trigger the release workflow
- make release builds check out the tagged ref explicitly
- add per-tag workflow concurrency to avoid duplicate release runs

## Validation
- bash -n scripts/create-release.sh