### PR TITLE
feat: improve schema ddl and refresh workflows

### DIFF
--- a/DataDeveloper.Data/Interfaces/ISchemaExplorer.cs
+++ b/DataDeveloper.Data/Interfaces/ISchemaExplorer.cs
@@ -9,4 +9,6 @@ public interface ISchemaExplorer
     ObservableCollection<SchemaNode> RootConnections { get; }
     Task LoadTableColumnsAsync(SchemaNode table);
     Task LoadNodeAsync(SchemaNode node);
+    Task RefreshSchemaAsync();
+    Task RefreshSchemaObjectAsync(string statement);
 }

--- a/DataDeveloper.Data/Models/SchemaNode.cs
+++ b/DataDeveloper.Data/Models/SchemaNode.cs
@@ -29,6 +29,7 @@ public class SchemaNode : ReactiveObject
     public SchemaNode? Parent { get; }
     public SchemaNode? Next => Children.FirstOrDefault();
     [Reactive] public bool CanLoad { get; set; }
+    [Reactive] public bool IsExpanded { get; set; }
     public string? Details { get; }
     public object? Tag { get; }
     public ObservableCollection<SchemaNode> Children { get; }

--- a/DataDeveloper.Data/Models/StatementResult.cs
+++ b/DataDeveloper.Data/Models/StatementResult.cs
@@ -24,6 +24,7 @@ public class StatementResult
     public int RecordsAffected { get; }
     public bool HasRows => DataReader?.HasRows ?? false;
     public bool HasDataReader => DataReader is not null;
+    public bool HasResultSet => (DataReader?.FieldCount ?? 0) > 0;
 
     public async Task CloseDataReader()
     {

--- a/DataDeveloper.Data/Providers/MySql/MySqlDatabaseProvider.cs
+++ b/DataDeveloper.Data/Providers/MySql/MySqlDatabaseProvider.cs
@@ -114,11 +114,11 @@ public class MySqlDatabaseProvider : DatabaseProviderBase<MySqlConnectionSetting
                    coalesce(parameter_name, 'return') as Name,
                    data_type as DataType,
                    coalesce(character_maximum_length, 0) as Length,
-                   coalesce(numeric_precision, 0) as Precision,
-                   coalesce(numeric_scale, 0) as Scale,
-                   case when is_nullable = 'YES' then 1 else 0 end as IsNullable,
-                   parameter_mode as Mode,
-                   ordinal_position as Position
+                   coalesce(numeric_precision, 0) as `Precision`,
+                   coalesce(numeric_scale, 0) as `Scale`,
+                   cast(1 as unsigned) as `IsNullable`,
+                   parameter_mode as `Mode`,
+                   ordinal_position as `Position`
                from information_schema.parameters
                where specific_schema = database()
                  and specific_name = @SpecificName

--- a/DataDeveloper.Data/Providers/SqlServer/SqlServerDatabaseProvider.cs
+++ b/DataDeveloper.Data/Providers/SqlServer/SqlServerDatabaseProvider.cs
@@ -77,10 +77,15 @@ public class SqlServerDatabaseProvider : DatabaseProviderBase<SqlServerConnectio
     {
         return """
                select
-                   routine_name as Name
-               from information_schema.routines
-               where routine_type = 'PROCEDURE'
-               order by routine_name;
+                   concat(r.routine_schema, '.', r.routine_name) as Name,
+                   concat(r.routine_schema, '.', r.routine_name) as SpecificName
+               from information_schema.routines r
+               inner join sys.objects o
+                   on o.object_id = object_id(quotename(r.routine_schema) + '.' + quotename(r.routine_name))
+               where r.routine_type = 'PROCEDURE'
+                 and r.routine_schema not in ('sys', 'INFORMATION_SCHEMA')
+                 and o.is_ms_shipped = 0
+               order by r.routine_schema, r.routine_name;
                """;
     }
 
@@ -88,11 +93,16 @@ public class SqlServerDatabaseProvider : DatabaseProviderBase<SqlServerConnectio
     {
         return """
                select
-                   routine_name as Name,
-                   data_type as DataType
-               from information_schema.routines
-               where routine_type = 'FUNCTION'
-               order by routine_name;
+                   concat(r.routine_schema, '.', r.routine_name) as Name,
+                   concat(r.routine_schema, '.', r.routine_name) as SpecificName,
+                   r.data_type as DataType
+               from information_schema.routines r
+               inner join sys.objects o
+                   on o.object_id = object_id(quotename(r.routine_schema) + '.' + quotename(r.routine_name))
+               where r.routine_type = 'FUNCTION'
+                 and r.routine_schema not in ('sys', 'INFORMATION_SCHEMA')
+                 and o.is_ms_shipped = 0
+               order by r.routine_schema, r.routine_name;
                """;
     }
 
@@ -109,7 +119,7 @@ public class SqlServerDatabaseProvider : DatabaseProviderBase<SqlServerConnectio
                    p.parameter_mode as Mode,
                    p.ordinal_position as Position
                from information_schema.parameters p
-               where p.specific_name = @SpecificName
+               where concat(p.specific_schema, '.', p.specific_name) = @SpecificName
                order by p.ordinal_position;
                """;
     }

--- a/DataDeveloper.Data/Services/SchemaExplorer.cs
+++ b/DataDeveloper.Data/Services/SchemaExplorer.cs
@@ -20,51 +20,64 @@ public class SchemaExplorer : ISchemaExplorer
     public ObservableCollection<SchemaNode> RootConnections { get; private set; } = new();
     public async Task InitializeSchemaNode()
     {
-        var connection = new SchemaNode(NodeType.Connection, ConnectionSettings.Name, isFolder: true, parent: null);
-        
-        var tables = new SchemaNode(NodeType.Tables, "Tables", isFolder: true, parent: connection);
-        var tableNames = await this.GetTablesAsync();
+        var connection = RootConnections.FirstOrDefault();
+        if (connection is null)
+        {
+            connection = new SchemaNode(NodeType.Connection, ConnectionSettings.Name, isFolder: true, parent: null)
+            {
+                IsExpanded = true
+            };
 
-        foreach (var tableName in tableNames)
-        {
-            var tableNode = new SchemaNode(NodeType.Table, tableName, isFolder: false, parent: tables);
-            tableNode.Children.Add(new SchemaNode(NodeType.Columns, "Columns", isFolder: true, parent: tableNode, canLoad: true));
-            tables.Children.Add( tableNode);
-        }
-        var views = new SchemaNode(NodeType.Views, "Views", isFolder: true, parent: connection);
-        var viewNames = await GetViewsAsync();
-        foreach (var viewName in viewNames)
-        {
-            var viewNode = new SchemaNode(NodeType.View, viewName, isFolder: false, parent: views);
-            viewNode.Children.Add(new SchemaNode(NodeType.Columns, "Columns", isFolder: true, parent: viewNode, canLoad: true));
-            views.Children.Add(viewNode);
+            connection.Children.Add(new SchemaNode(NodeType.Tables, "Tables", isFolder: true, parent: connection));
+            connection.Children.Add(new SchemaNode(NodeType.Views, "Views", isFolder: true, parent: connection));
+            connection.Children.Add(new SchemaNode(NodeType.Procedures, "Procedures", isFolder: true, parent: connection));
+            connection.Children.Add(new SchemaNode(NodeType.Functions, "Functions", isFolder: true, parent: connection));
+
+            RootConnections = new ObservableCollection<SchemaNode> { connection };
         }
 
-        var procedures = new SchemaNode(NodeType.Procedures, "Procedures", isFolder: true, parent: connection);
-        var procedureNames = await GetProceduresAsync();
-        foreach (var procedure in procedureNames)
+        await RefreshFolderAsync(NodeType.Tables);
+        await RefreshFolderAsync(NodeType.Views);
+        await RefreshFolderAsync(NodeType.Procedures);
+        await RefreshFolderAsync(NodeType.Functions);
+    }
+
+    public async Task RefreshSchemaAsync()
+    {
+        await InitializeSchemaNode();
+    }
+
+    public async Task RefreshSchemaObjectAsync(string statement)
+    {
+        var target = StatementExecutionClassifier.ParseSchemaRefreshTarget(statement);
+        if (target is null || target.ObjectType == SchemaObjectType.Unknown)
         {
-            var procedureNode = new SchemaNode(NodeType.Procedure, procedure.Name, isFolder: false, parent: procedures, details: null, tag: procedure);
-            procedureNode.Children.Add(new SchemaNode(NodeType.Parameters, "Parameters", isFolder: true, parent: procedureNode, canLoad: true));
-            procedures.Children.Add(procedureNode);
+            await RefreshSchemaAsync();
+            return;
         }
 
-        var functions = new SchemaNode(NodeType.Functions, "Functions", isFolder: true, parent: connection);
-        var functionNames = await GetFunctionsAsync();
-        foreach (var function in functionNames)
+        var folderType = target.ObjectType switch
         {
-            var functionDetails = string.IsNullOrWhiteSpace(function.DataType) ? null : function.DataType;
-            var functionNode = new SchemaNode(NodeType.Function, function.Name, isFolder: false, parent: functions, details: functionDetails, tag: function);
-            functionNode.Children.Add(new SchemaNode(NodeType.Parameters, "Parameters", isFolder: true, parent: functionNode, canLoad: true));
-            functions.Children.Add(functionNode);
+            SchemaObjectType.Table => NodeType.Tables,
+            SchemaObjectType.View => NodeType.Views,
+            SchemaObjectType.Procedure => NodeType.Procedures,
+            SchemaObjectType.Function => NodeType.Functions,
+            _ => NodeType.None
+        };
+
+        if (folderType == NodeType.None)
+        {
+            await RefreshSchemaAsync();
+            return;
         }
 
-        connection.Children.Add(tables);
-        connection.Children.Add(views);
-        connection.Children.Add(procedures);
-        connection.Children.Add(functions);
+        if (target.Action is SchemaRefreshAction.Create or SchemaRefreshAction.Drop || string.IsNullOrWhiteSpace(target.ObjectName))
+        {
+            await RefreshFolderAsync(folderType);
+            return;
+        }
 
-        RootConnections = new ObservableCollection<SchemaNode> { connection };
+        await RefreshObjectAsync(folderType, target.ObjectName!);
     }
 
     private async Task<IEnumerable<string>> GetTablesAsync()
@@ -172,6 +185,154 @@ public class SchemaExplorer : ISchemaExplorer
         }
 
         node.CanLoad = false;
+    }
+
+    private async Task RefreshFolderAsync(NodeType folderType)
+    {
+        var folder = FindFolder(folderType);
+        if (folder is null)
+            return;
+
+        switch (folderType)
+        {
+            case NodeType.Tables:
+                await SyncObjectFolderAsync(folder, await GetTablesAsync(), NodeType.Table, null);
+                break;
+            case NodeType.Views:
+                await SyncObjectFolderAsync(folder, await GetViewsAsync(), NodeType.View, null);
+                break;
+            case NodeType.Procedures:
+                await SyncRoutineFolderAsync(folder, await GetProceduresAsync(), NodeType.Procedure);
+                break;
+            case NodeType.Functions:
+                await SyncRoutineFolderAsync(folder, await GetFunctionsAsync(), NodeType.Function);
+                break;
+        }
+    }
+
+    private async Task RefreshObjectAsync(NodeType folderType, string objectName)
+    {
+        var folder = FindFolder(folderType);
+        if (folder is null)
+        {
+            await RefreshSchemaAsync();
+            return;
+        }
+
+        var normalizedTarget = NormalizeObjectName(objectName);
+        var existingNode = folder.Children.FirstOrDefault(child => NormalizeObjectName(child.Name) == normalizedTarget);
+
+        await RefreshFolderAsync(folderType);
+
+        existingNode = folder.Children.FirstOrDefault(child => NormalizeObjectName(child.Name) == normalizedTarget);
+        if (existingNode is null)
+            return;
+
+        switch (existingNode.NodeType)
+        {
+            case NodeType.Table:
+            case NodeType.View:
+                var columnsFolder = existingNode.Children.FirstOrDefault(child => child.NodeType == NodeType.Columns);
+                if (columnsFolder is not null && !columnsFolder.CanLoad)
+                    await LoadTableColumnsAsync(columnsFolder);
+                break;
+            case NodeType.Procedure:
+            case NodeType.Function:
+                var parametersFolder = existingNode.Children.FirstOrDefault(child => child.NodeType == NodeType.Parameters);
+                if (parametersFolder is not null && !parametersFolder.CanLoad)
+                    await LoadNodeAsync(parametersFolder);
+                break;
+        }
+    }
+
+    private SchemaNode? FindFolder(NodeType folderType)
+    {
+        var connection = RootConnections.FirstOrDefault();
+        return connection?.Children.FirstOrDefault(child => child.NodeType == folderType);
+    }
+
+    private async Task SyncObjectFolderAsync(SchemaNode folder, IEnumerable<string> objectNames, NodeType nodeType, Func<string, string?>? detailsFactory)
+    {
+        var existing = folder.Children.ToDictionary(child => NormalizeObjectName(child.Name), child => child);
+        var orderedNames = objectNames.OrderBy(name => name).ToList();
+        var refreshedChildren = new List<SchemaNode>();
+
+        foreach (var objectName in orderedNames)
+        {
+            var key = NormalizeObjectName(objectName);
+            if (existing.TryGetValue(key, out var currentNode))
+            {
+                refreshedChildren.Add(currentNode);
+                EnsureObjectChildren(currentNode);
+                continue;
+            }
+
+            var node = new SchemaNode(nodeType, objectName, isFolder: false, parent: folder, details: detailsFactory?.Invoke(objectName));
+            EnsureObjectChildren(node);
+            refreshedChildren.Add(node);
+        }
+
+        ReplaceChildren(folder, refreshedChildren);
+        await Task.CompletedTask;
+    }
+
+    private async Task SyncRoutineFolderAsync(SchemaNode folder, IEnumerable<DatabaseObjectModel> routines, NodeType nodeType)
+    {
+        var existing = folder.Children.ToDictionary(child => NormalizeObjectName(child.Name), child => child);
+        var refreshedChildren = new List<SchemaNode>();
+
+        foreach (var routine in routines.OrderBy(item => item.Name))
+        {
+            var key = NormalizeObjectName(routine.Name);
+            if (existing.TryGetValue(key, out var currentNode))
+            {
+                refreshedChildren.Add(currentNode);
+                EnsureObjectChildren(currentNode);
+                continue;
+            }
+
+            var details = nodeType == NodeType.Function && !string.IsNullOrWhiteSpace(routine.DataType)
+                ? routine.DataType
+                : null;
+            var node = new SchemaNode(nodeType, routine.Name, isFolder: false, parent: folder, details: details, tag: routine);
+            EnsureObjectChildren(node);
+            refreshedChildren.Add(node);
+        }
+
+        ReplaceChildren(folder, refreshedChildren);
+        await Task.CompletedTask;
+    }
+
+    private static void EnsureObjectChildren(SchemaNode node)
+    {
+        switch (node.NodeType)
+        {
+            case NodeType.Table:
+            case NodeType.View:
+                if (!node.Children.Any(child => child.NodeType == NodeType.Columns))
+                    node.Children.Add(new SchemaNode(NodeType.Columns, "Columns", isFolder: true, parent: node, canLoad: true));
+                break;
+            case NodeType.Procedure:
+            case NodeType.Function:
+                if (!node.Children.Any(child => child.NodeType == NodeType.Parameters))
+                    node.Children.Add(new SchemaNode(NodeType.Parameters, "Parameters", isFolder: true, parent: node, canLoad: true));
+                break;
+        }
+    }
+
+    private static void ReplaceChildren(SchemaNode folder, IReadOnlyList<SchemaNode> nodes)
+    {
+        folder.Children.Clear();
+        foreach (var node in nodes)
+            folder.Children.Add(node);
+    }
+
+    private static string NormalizeObjectName(string objectName)
+    {
+        return objectName
+            .Trim()
+            .Trim('[', ']', '`', '"')
+            .ToLowerInvariant();
     }
 
     private static string BuildParameterDetails(RoutineParameterModel parameter)

--- a/DataDeveloper.Data/Services/StatementExecutionClassifier.cs
+++ b/DataDeveloper.Data/Services/StatementExecutionClassifier.cs
@@ -14,6 +14,48 @@ public static class StatementExecutionClassifier
                (trimmed.StartsWith("begin", System.StringComparison.OrdinalIgnoreCase) && ContainsStandaloneExecOrCall(trimmed));
     }
 
+    public static bool RequiresSchemaRefresh(string statement)
+    {
+        if (string.IsNullOrWhiteSpace(statement))
+            return false;
+
+        var trimmed = TrimLeadingTrivia(statement);
+        return trimmed.StartsWith("create ", System.StringComparison.OrdinalIgnoreCase) ||
+               trimmed.StartsWith("alter ", System.StringComparison.OrdinalIgnoreCase) ||
+               trimmed.StartsWith("drop ", System.StringComparison.OrdinalIgnoreCase) ||
+               trimmed.StartsWith("truncate ", System.StringComparison.OrdinalIgnoreCase) ||
+               trimmed.StartsWith("rename ", System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static SchemaRefreshTarget? ParseSchemaRefreshTarget(string statement)
+    {
+        if (string.IsNullOrWhiteSpace(statement))
+            return null;
+
+        var trimmed = TrimLeadingTrivia(statement).TrimStart();
+        var tokens = trimmed
+            .Split((char[]?)null, 6, System.StringSplitOptions.RemoveEmptyEntries | System.StringSplitOptions.TrimEntries);
+
+        if (tokens.Length < 2)
+            return null;
+
+        var action = tokens[0];
+        var objectKeyword = tokens[1];
+
+        if (action.Equals("truncate", System.StringComparison.OrdinalIgnoreCase) && objectKeyword.Equals("table", System.StringComparison.OrdinalIgnoreCase))
+        {
+            return BuildTarget(tokens, 2, SchemaRefreshAction.Alter, SchemaObjectType.Table);
+        }
+
+        if (action.Equals("rename", System.StringComparison.OrdinalIgnoreCase))
+            return new SchemaRefreshTarget(SchemaRefreshAction.Unknown, SchemaObjectType.Unknown, null);
+
+        if (!TryMapAction(action, out var refreshAction) || !TryMapObjectType(objectKeyword, out var objectType))
+            return null;
+
+        return BuildTarget(tokens, 2, refreshAction, objectType);
+    }
+
     private static string TrimLeadingTrivia(string statement)
     {
         var index = 0;
@@ -81,4 +123,91 @@ public static class StatementExecutionClassifier
     {
         return char.IsLetterOrDigit(value) || value == '_' || value == '@';
     }
+
+    private static bool TryMapAction(string value, out SchemaRefreshAction action)
+    {
+        if (value.Equals("create", System.StringComparison.OrdinalIgnoreCase))
+        {
+            action = SchemaRefreshAction.Create;
+            return true;
+        }
+
+        if (value.Equals("alter", System.StringComparison.OrdinalIgnoreCase))
+        {
+            action = SchemaRefreshAction.Alter;
+            return true;
+        }
+
+        if (value.Equals("drop", System.StringComparison.OrdinalIgnoreCase))
+        {
+            action = SchemaRefreshAction.Drop;
+            return true;
+        }
+
+        action = SchemaRefreshAction.Unknown;
+        return false;
+    }
+
+    private static bool TryMapObjectType(string value, out SchemaObjectType objectType)
+    {
+        if (value.Equals("table", System.StringComparison.OrdinalIgnoreCase))
+        {
+            objectType = SchemaObjectType.Table;
+            return true;
+        }
+
+        if (value.Equals("view", System.StringComparison.OrdinalIgnoreCase))
+        {
+            objectType = SchemaObjectType.View;
+            return true;
+        }
+
+        if (value.Equals("procedure", System.StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("proc", System.StringComparison.OrdinalIgnoreCase))
+        {
+            objectType = SchemaObjectType.Procedure;
+            return true;
+        }
+
+        if (value.Equals("function", System.StringComparison.OrdinalIgnoreCase))
+        {
+            objectType = SchemaObjectType.Function;
+            return true;
+        }
+
+        objectType = SchemaObjectType.Unknown;
+        return false;
+    }
+
+    private static SchemaRefreshTarget? BuildTarget(string[] tokens, int objectNameIndex, SchemaRefreshAction action, SchemaObjectType objectType)
+    {
+        if (tokens.Length <= objectNameIndex)
+            return new SchemaRefreshTarget(action, objectType, null);
+
+        var objectName = tokens[objectNameIndex]
+            .Trim()
+            .TrimEnd(';', ',')
+            .Trim('(', ')');
+
+        return new SchemaRefreshTarget(action, objectType, objectName);
+    }
 }
+
+public enum SchemaRefreshAction
+{
+    Unknown,
+    Create,
+    Alter,
+    Drop,
+}
+
+public enum SchemaObjectType
+{
+    Unknown,
+    Table,
+    View,
+    Procedure,
+    Function,
+}
+
+public record SchemaRefreshTarget(SchemaRefreshAction Action, SchemaObjectType ObjectType, string? ObjectName);

--- a/DataDeveloper.Tests/DatabaseObjectScriptBuilderTests.cs
+++ b/DataDeveloper.Tests/DatabaseObjectScriptBuilderTests.cs
@@ -19,8 +19,9 @@ public class DatabaseObjectScriptBuilderTests
 
         var script = DatabaseObjectScriptBuilder.BuildSelectRowsScript(settings, node);
 
-        Assert.Contains("select top 100 *", script, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("select *", script, System.StringComparison.OrdinalIgnoreCase);
         Assert.Contains("from [Orders];", script, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("top 100", script, System.StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -32,8 +33,8 @@ public class DatabaseObjectScriptBuilderTests
         var script = DatabaseObjectScriptBuilder.BuildSelectRowsScript(settings, node);
 
         Assert.Contains("select *", script, System.StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("from `orders`", script, System.StringComparison.Ordinal);
-        Assert.Contains("limit 100;", script, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("from `orders`;", script, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("limit 100", script, System.StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -45,8 +46,8 @@ public class DatabaseObjectScriptBuilderTests
         var script = DatabaseObjectScriptBuilder.BuildSelectRowsScript(settings, node);
 
         Assert.Contains("select *", script, System.StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("from \"public\".\"orders\"", script, System.StringComparison.Ordinal);
-        Assert.Contains("limit 100;", script, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("from \"public\".\"orders\";", script, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("limit 100", script, System.StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -103,6 +104,111 @@ public class DatabaseObjectScriptBuilderTests
     }
 
     [Fact]
+    public void BuildInsertScript_UsesLoadedColumns()
+    {
+        var tableNode = CreateNode(NodeType.Table, "Orders");
+        var columnsFolder = CreateNode(NodeType.Columns, "Columns", isFolder: true, parent: tableNode);
+        tableNode.Children.Add(columnsFolder);
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "OrderId", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "OrderId",
+            DataType = "int",
+            IsPrimaryKey = true
+        }));
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "CustomerName", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "CustomerName",
+            DataType = "varchar",
+            Length = 50
+        }));
+
+        var script = DatabaseObjectScriptBuilder.BuildInsertScript(
+            new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            tableNode);
+
+        Assert.Contains("insert into [Orders]", script, StringComparison.Ordinal);
+        Assert.Contains("([OrderId], [CustomerName])", script, StringComparison.Ordinal);
+        Assert.Contains("[OrderId]", script, StringComparison.Ordinal);
+        Assert.Contains("[CustomerName]", script, StringComparison.Ordinal);
+        Assert.Contains("@OrderId", script, StringComparison.Ordinal);
+        Assert.Contains("@CustomerName", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildUpdateScript_PrefersPrimaryKeyInWhereClause()
+    {
+        var tableNode = CreateNode(NodeType.Table, "Orders");
+        var columnsFolder = CreateNode(NodeType.Columns, "Columns", isFolder: true, parent: tableNode);
+        tableNode.Children.Add(columnsFolder);
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "OrderId", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "OrderId",
+            DataType = "int",
+            IsPrimaryKey = true
+        }));
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "CustomerName", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "CustomerName",
+            DataType = "varchar",
+            Length = 50
+        }));
+
+        var script = DatabaseObjectScriptBuilder.BuildUpdateScript(
+            new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            tableNode);
+
+        Assert.Contains("set", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("[CustomerName] = @CustomerName", script, StringComparison.Ordinal);
+        Assert.Contains("where", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("[OrderId] = @OrderId", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildDeleteScript_PrefersPrimaryKeyInWhereClause()
+    {
+        var tableNode = CreateNode(NodeType.Table, "Orders");
+        var columnsFolder = CreateNode(NodeType.Columns, "Columns", isFolder: true, parent: tableNode);
+        tableNode.Children.Add(columnsFolder);
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "OrderId", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "OrderId",
+            DataType = "int",
+            IsPrimaryKey = true
+        }));
+
+        var script = DatabaseObjectScriptBuilder.BuildDeleteScript(
+            new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            tableNode);
+
+        Assert.Contains("delete from [Orders]", script, StringComparison.Ordinal);
+        Assert.Contains("[OrderId] = @OrderId", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildDropScript_ReturnsDropTableStatement()
+    {
+        var node = CreateNode(NodeType.Table, "dbo.Customers");
+
+        var script = DatabaseObjectScriptBuilder.BuildDropScript(
+            new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            node);
+
+        Assert.Equal("drop table [dbo].[Customers];", script);
+    }
+
+    [Fact]
+    public void BuildDropScript_ReturnsDropViewStatement()
+    {
+        var node = CreateNode(NodeType.View, "reporting.ActiveCustomers");
+
+        var script = DatabaseObjectScriptBuilder.BuildDropScript(
+            new MySqlConnectionSettings { DatabaseType = DatabaseType.MySql },
+            node);
+
+        Assert.Equal("drop view `reporting`.`ActiveCustomers`;", script);
+    }
+
+    [Fact]
     public void BuildSelectFunctionScript_UsesLoadedParameters()
     {
         var functionNode = CreateNode(NodeType.Function, "dbo.CalculateTax");
@@ -124,6 +230,136 @@ public class DatabaseObjectScriptBuilderTests
             functionNode);
 
         Assert.Equal("select [dbo].[CalculateTax](@amount, @region);", script);
+    }
+
+    [Fact]
+    public void BuildDdlScript_ForTable_UsesLoadedColumns()
+    {
+        var tableNode = CreateNode(NodeType.Table, "dbo.Orders");
+        var columnsFolder = CreateNode(NodeType.Columns, "Columns", isFolder: true, parent: tableNode);
+        tableNode.Children.Add(columnsFolder);
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "OrderId", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "OrderId",
+            DataType = "int",
+            IsPrimaryKey = true
+        }));
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "CustomerName", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "CustomerName",
+            DataType = "varchar",
+            Length = 50,
+            IsNullable = true
+        }));
+        columnsFolder.Children.Add(CreateNode(NodeType.Column, "CreatedAt", parent: columnsFolder, tag: new ColumnModel
+        {
+            Name = "CreatedAt",
+            DataType = "datetime",
+            Precision = 7,
+            IsNullable = false
+        }));
+
+        var script = DatabaseObjectScriptBuilder.BuildDdlScript(
+            new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            tableNode);
+
+        Assert.Contains("create table [dbo].[Orders]", script, StringComparison.Ordinal);
+        Assert.Contains("[OrderId] int not null", script, StringComparison.Ordinal);
+        Assert.Contains("[CustomerName] varchar(50) null", script, StringComparison.Ordinal);
+        Assert.Contains("[CreatedAt] datetime not null", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("datetime(7)", script, StringComparison.Ordinal);
+        Assert.Contains("primary key ([OrderId])", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildObjectDdlRetrievalScript_ForMySqlProcedure_UsesShowCreate()
+    {
+        var procedureNode = CreateNode(NodeType.Procedure, "ProcessOrders");
+
+        var script = DatabaseObjectScriptBuilder.BuildObjectDdlRetrievalScript(
+            new MySqlConnectionSettings { DatabaseType = DatabaseType.MySql },
+            procedureNode);
+
+        Assert.Equal("show create procedure `ProcessOrders`;", script);
+    }
+
+    [Fact]
+    public void TryBuildNativeDdlRetrievalScript_ForMySqlTable_UsesShowCreateTable()
+    {
+        var tableNode = CreateNode(NodeType.Table, "sales.OrderItems");
+
+        var script = DatabaseObjectScriptBuilder.TryBuildNativeDdlRetrievalScript(
+            new MySqlConnectionSettings { DatabaseType = DatabaseType.MySql },
+            tableNode);
+
+        Assert.Equal("show create table `sales`.`OrderItems`;", script);
+    }
+
+    [Fact]
+    public void TryBuildNativeDdlRetrievalScript_ForSqlServerTable_ReturnsNull()
+    {
+        var tableNode = CreateNode(NodeType.Table, "dbo.Orders");
+
+        var script = DatabaseObjectScriptBuilder.TryBuildNativeDdlRetrievalScript(
+            new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            tableNode);
+
+        Assert.NotNull(script);
+        Assert.Contains("declare @ObjectId int = object_id(N'dbo.Orders');", script, StringComparison.Ordinal);
+        Assert.Contains("from sys.tables t", script, StringComparison.Ordinal);
+        Assert.Contains("join sys.columns c", script, StringComparison.Ordinal);
+        Assert.Contains("left join sys.identity_columns ic", script, StringComparison.Ordinal);
+        Assert.Contains("left join sys.default_constraints dc", script, StringComparison.Ordinal);
+        Assert.Contains("left join sys.computed_columns cc", script, StringComparison.Ordinal);
+        Assert.Contains("from sys.key_constraints kc", script, StringComparison.Ordinal);
+        Assert.Contains("from sys.check_constraints cc", script, StringComparison.Ordinal);
+        Assert.Contains("from sys.foreign_keys fk", script, StringComparison.Ordinal);
+        Assert.Contains("from sys.indexes i", script, StringComparison.Ordinal);
+        Assert.Contains("as Definition", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryBuildNativeDdlRetrievalScript_ForPostgresTable_UsesCatalogFunctions()
+    {
+        var tableNode = CreateNode(NodeType.Table, "sales.order_items");
+
+        var script = DatabaseObjectScriptBuilder.TryBuildNativeDdlRetrievalScript(
+            new PostgresConnectionSettings { DatabaseType = DatabaseType.PostgresSql },
+            tableNode);
+
+        Assert.NotNull(script);
+        Assert.Contains("from pg_class c", script, StringComparison.Ordinal);
+        Assert.Contains("join pg_namespace n on n.oid = c.relnamespace", script, StringComparison.Ordinal);
+        Assert.Contains("format_type(a.atttypid, a.atttypmod)", script, StringComparison.Ordinal);
+        Assert.Contains("pg_get_expr(ad.adbin, ad.adrelid)", script, StringComparison.Ordinal);
+        Assert.Contains("pg_get_constraintdef(con.oid, true)", script, StringComparison.Ordinal);
+        Assert.Contains("pg_get_indexdef(i.indexrelid)", script, StringComparison.Ordinal);
+        Assert.Contains("where n.nspname = 'sales'", script, StringComparison.Ordinal);
+        Assert.Contains("and c.relname = 'order_items'", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildObjectDdlRetrievalScript_ForSqlServerFunction_UsesObjectDefinition()
+    {
+        var functionNode = CreateNode(NodeType.Function, "dbo.CalculateTax");
+
+        var script = DatabaseObjectScriptBuilder.BuildObjectDdlRetrievalScript(
+            new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
+            functionNode);
+
+        Assert.Equal("select object_definition(object_id(N'dbo.CalculateTax')) as Definition;", script);
+    }
+
+    [Fact]
+    public void BuildObjectDdlRetrievalScript_ForMySqlView_UsesShowCreateView()
+    {
+        var viewNode = CreateNode(NodeType.View, "SalesSummary");
+
+        var script = DatabaseObjectScriptBuilder.BuildObjectDdlRetrievalScript(
+            new MySqlConnectionSettings { DatabaseType = DatabaseType.MySql },
+            viewNode);
+
+        Assert.Equal("show create view `SalesSummary`;", script);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/Providers/MySqlDatabaseProviderTests.cs
+++ b/DataDeveloper.Tests/Providers/MySqlDatabaseProviderTests.cs
@@ -95,5 +95,6 @@ public class MySqlDatabaseProviderTests
 
         Assert.Contains("information_schema.parameters", sql, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("specific_name = @SpecificName", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("is_nullable", sql, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/DataDeveloper.Tests/Providers/SqlServerDatabaseProviderTests.cs
+++ b/DataDeveloper.Tests/Providers/SqlServerDatabaseProviderTests.cs
@@ -70,7 +70,9 @@ public class SqlServerDatabaseProviderTests
         var sql = provider.GetProcedureStatement();
 
         Assert.Contains("information_schema.routines", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("sys.objects", sql, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("routine_type = 'PROCEDURE'", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("is_ms_shipped = 0", sql, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -81,7 +83,9 @@ public class SqlServerDatabaseProviderTests
         var sql = provider.GetFunctionStatement();
 
         Assert.Contains("information_schema.routines", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("sys.objects", sql, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("routine_type = 'FUNCTION'", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("is_ms_shipped = 0", sql, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -92,7 +96,7 @@ public class SqlServerDatabaseProviderTests
         var sql = provider.GetRoutineParameterStatement();
 
         Assert.Contains("information_schema.parameters", sql, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("specific_name = @SpecificName", sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("concat(p.specific_schema, '.', p.specific_name) = @SpecificName", sql, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("is_nullable", sql, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/DataDeveloper.Tests/SqlParameterDetectorTests.cs
+++ b/DataDeveloper.Tests/SqlParameterDetectorTests.cs
@@ -57,7 +57,7 @@ public class SqlParameterDetectorTests
 
         var parameters = SqlParameterDetector.ExtractParameters(sql);
 
-        Assert.Equal(["@id", "@name", "@active"], parameters);
+        Assert.Empty(parameters);
     }
 
     [Fact]
@@ -73,5 +73,74 @@ public class SqlParameterDetectorTests
         var parameters = SqlParameterDetector.ExtractParameters(sql);
 
         Assert.Equal(["@saleId"], parameters);
+    }
+
+    [Fact]
+    public void ExtractParameters_IgnoresVariablesInsideFunctionBody()
+    {
+        var sql = """
+                  CREATE FUNCTION [dbo].[GetRecordLocatorFromId] (
+                      @Id BIGINT
+                  )
+                  RETURNS VARCHAR(6)
+                  AS
+                  BEGIN
+                      DECLARE
+                          @Size INT = 6,
+                          @Chars VARCHAR(33) = '0123456789ABCDEFGHJKMNPQRSTUVWXYZ',
+                          @Mod INT = 33,
+                          @Max BIGINT = 1291467969,
+                          @I INT,
+                          @Pos INT,
+                          @Locator NVARCHAR(MAX)
+
+                      SELECT
+                          @Id = @Id % @Max,
+                          @I = 1,
+                          @Locator = ''
+
+                      RETURN @Locator
+                  END
+                  """;
+
+        var parameters = SqlParameterDetector.ExtractParameters(sql);
+
+        Assert.Empty(parameters);
+    }
+
+    [Fact]
+    public void ExtractParameters_DetectsExecParameters_AfterSqlServerBatchSeparator()
+    {
+        var sql = """
+                  create procedure dbo.Teste
+                      @id int
+                  as
+                  begin
+                      select @id;
+                  end
+                  go
+                  exec dbo.Teste @externalId;
+                  """;
+
+        var parameters = SqlParameterDetector.ExtractParameters(sql);
+
+        Assert.Equal(["@externalId"], parameters);
+    }
+
+    [Fact]
+    public void ExtractParameters_IgnoresProcedureDeclarationWithExtraWhitespace()
+    {
+        var sql = """
+                  CREATE   PROCEDURE [dbo].[GetBusMarketsByArrival] (@ArrivalLocationSlug VARCHAR(100))
+                  AS
+                  BEGIN
+                      SELECT 1
+                      WHERE 1 = CASE WHEN @ArrivalLocationSlug IS NULL THEN 0 ELSE 1 END
+                  END
+                  """;
+
+        var parameters = SqlParameterDetector.ExtractParameters(sql);
+
+        Assert.Empty(parameters);
     }
 }

--- a/DataDeveloper.Tests/StatementExecutionClassifierTests.cs
+++ b/DataDeveloper.Tests/StatementExecutionClassifierTests.cs
@@ -25,4 +25,26 @@ public class StatementExecutionClassifierTests
     {
         Assert.False(StatementExecutionClassifier.RequiresMaterialization(statement));
     }
+
+    [Theory]
+    [InlineData("create table dbo.Test(Id int)")]
+    [InlineData(" alter table dbo.Test add Name varchar(50)")]
+    [InlineData("drop view dbo.ActiveCustomers")]
+    [InlineData("truncate table dbo.Log")]
+    [InlineData("-- comment\nrename table old_name to new_name")]
+    public void RequiresSchemaRefresh_ReturnsTrue_ForDdlStatements(string statement)
+    {
+        Assert.True(StatementExecutionClassifier.RequiresSchemaRefresh(statement));
+    }
+
+    [Theory]
+    [InlineData("select * from orders")]
+    [InlineData("insert into orders(id) values (1)")]
+    [InlineData("update orders set status = 1")]
+    [InlineData("delete from orders where id = 1")]
+    [InlineData("exec dbo.MyProc")]
+    public void RequiresSchemaRefresh_ReturnsFalse_ForNonDdlStatements(string statement)
+    {
+        Assert.False(StatementExecutionClassifier.RequiresSchemaRefresh(statement));
+    }
 }

--- a/DataDeveloper/Behaviors/TreeViewExpansionBehavior.cs
+++ b/DataDeveloper/Behaviors/TreeViewExpansionBehavior.cs
@@ -26,24 +26,42 @@ public static class TreeViewExpansionBehavior
             if (args.NewValue is true)
             {
                 item.Expanded += OnItemExpanded;
+                item.Collapsed += OnItemCollapsed;
             }
             else
             {
                 item.Expanded -= OnItemExpanded;
+                item.Collapsed -= OnItemCollapsed;
             }
         });
     }
 
     private static async void OnItemExpanded(object? sender, RoutedEventArgs e)
     {
+        if (!ReferenceEquals(sender, e.Source))
+            return;
+
         if (sender is TreeViewItem treeViewItem &&
             treeViewItem.DataContext is SchemaNode node &&
             GetSchemaExplorer(treeViewItem) is ISchemaExplorer schemaExplorer)
         {
+            node.IsExpanded = true;
             if (node.CanLoad && node.Next?.NodeType == NodeType.None)
             {
                 await schemaExplorer.LoadNodeAsync(node);
             }
+        }
+    }
+
+    private static void OnItemCollapsed(object? sender, RoutedEventArgs e)
+    {
+        if (!ReferenceEquals(sender, e.Source))
+            return;
+
+        if (sender is TreeViewItem treeViewItem &&
+            treeViewItem.DataContext is SchemaNode node)
+        {
+            node.IsExpanded = false;
         }
     }
 

--- a/DataDeveloper/EventAggregators/RefreshSchemaExplorerEvent.cs
+++ b/DataDeveloper/EventAggregators/RefreshSchemaExplorerEvent.cs
@@ -1,0 +1,6 @@
+using System;
+using DataDeveloper.Data.Services;
+
+namespace DataDeveloper.EventAggregators;
+
+public record RefreshSchemaExplorerEvent(Guid ConnectionId, string? Statement = null, SchemaRefreshTarget? Target = null);

--- a/DataDeveloper/Services/DatabaseObjectScriptBuilder.cs
+++ b/DataDeveloper/Services/DatabaseObjectScriptBuilder.cs
@@ -24,19 +24,111 @@ public static class DatabaseObjectScriptBuilder
     public static string BuildSelectRowsScript(IConnectionSettings connectionSettings, SchemaNode node)
     {
         var qualifiedName = BuildQualifiedName(connectionSettings, node);
-        return connectionSettings.DatabaseType switch
-        {
-            DatabaseType.SqlServer => $"select top 100 *{Environment.NewLine}from {qualifiedName};",
-            DatabaseType.PostgresSql => $"select *{Environment.NewLine}from {qualifiedName}{Environment.NewLine}limit 100;",
-            DatabaseType.MySql => $"select *{Environment.NewLine}from {qualifiedName}{Environment.NewLine}limit 100;",
-            _ => $"select *{Environment.NewLine}from {qualifiedName};"
-        };
+        return $"select *{Environment.NewLine}from {qualifiedName};";
     }
 
     public static string BuildCountRowsScript(IConnectionSettings connectionSettings, SchemaNode node)
     {
         var qualifiedName = BuildQualifiedName(connectionSettings, node);
         return $"select count(*) as TotalRows{Environment.NewLine}from {qualifiedName};";
+    }
+
+    public static string BuildInsertScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        var qualifiedName = BuildQualifiedName(connectionSettings, node);
+        var columns = GetLoadedColumns(node);
+        if (columns.Count == 0)
+            return $"insert into {qualifiedName}{Environment.NewLine}values ();";
+
+        var quotedColumns = columns.Select(column => QuoteSingleIdentifier(connectionSettings, column.Name)).ToList();
+        var placeholders = columns.Select(column => FormatValuePlaceholder(column.Name)).ToList();
+
+        return $"insert into {qualifiedName}{Environment.NewLine}({string.Join(", ", quotedColumns)}){Environment.NewLine}values{Environment.NewLine}({Environment.NewLine}    {string.Join($",{Environment.NewLine}    ", placeholders)}{Environment.NewLine});";
+    }
+
+    public static string BuildUpdateScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        var qualifiedName = BuildQualifiedName(connectionSettings, node);
+        var columns = GetLoadedColumns(node);
+        if (columns.Count == 0)
+            return $"update {qualifiedName}{Environment.NewLine}set{Environment.NewLine}    -- column = value{Environment.NewLine}where 1 = 0;";
+
+        var keyColumns = columns.Where(column => column.IsPrimaryKey).ToList();
+        var nonKeyColumns = columns.Where(column => !column.IsPrimaryKey).ToList();
+        var setColumns = (nonKeyColumns.Count > 0 ? nonKeyColumns : columns).ToList();
+        var whereColumns = (keyColumns.Count > 0 ? keyColumns : columns.Take(1)).ToList();
+
+        var assignments = setColumns
+            .Select(column => $"{QuoteSingleIdentifier(connectionSettings, column.Name)} = {FormatValuePlaceholder(column.Name)}");
+        var predicates = whereColumns
+            .Select(column => $"{QuoteSingleIdentifier(connectionSettings, column.Name)} = {FormatValuePlaceholder(column.Name)}");
+
+        return $"update {qualifiedName}{Environment.NewLine}set{Environment.NewLine}    {string.Join($",{Environment.NewLine}    ", assignments)}{Environment.NewLine}where{Environment.NewLine}    {string.Join($"{Environment.NewLine}    and ", predicates)};";
+    }
+
+    public static string BuildDeleteScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        var qualifiedName = BuildQualifiedName(connectionSettings, node);
+        var columns = GetLoadedColumns(node);
+        var keyColumns = columns.Where(column => column.IsPrimaryKey).ToList();
+        var whereColumns = (keyColumns.Count > 0 ? keyColumns : columns.Take(1)).ToList();
+
+        if (whereColumns.Count == 0)
+            return $"delete from {qualifiedName}{Environment.NewLine}where 1 = 0;";
+
+        var predicates = whereColumns
+            .Select(column => $"{QuoteSingleIdentifier(connectionSettings, column.Name)} = {FormatValuePlaceholder(column.Name)}");
+
+        return $"delete from {qualifiedName}{Environment.NewLine}where{Environment.NewLine}    {string.Join($"{Environment.NewLine}    and ", predicates)};";
+    }
+
+    public static string BuildDropScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        var qualifiedName = BuildQualifiedName(connectionSettings, node);
+        var objectType = node.NodeType switch
+        {
+            NodeType.Table => "table",
+            NodeType.View => "view",
+            NodeType.Procedure => "procedure",
+            NodeType.Function => "function",
+            _ => null
+        };
+
+        return objectType is null
+            ? qualifiedName
+            : $"drop {objectType} {qualifiedName};";
+    }
+
+    public static string BuildDdlScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        return node.NodeType switch
+            {
+                NodeType.Table => BuildCreateTableScript(connectionSettings, node),
+                _ => BuildQualifiedName(connectionSettings, node)
+            };
+    }
+
+    public static string? TryBuildNativeDdlRetrievalScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        return node.NodeType switch
+        {
+            NodeType.Table => BuildTableDdlRetrievalQuery(connectionSettings, node),
+            NodeType.View => BuildViewDdlRetrievalQuery(connectionSettings, node),
+            NodeType.Procedure => BuildRoutineDdlRetrievalQuery(connectionSettings, node, isFunction: false),
+            NodeType.Function => BuildRoutineDdlRetrievalQuery(connectionSettings, node, isFunction: true),
+            _ => null
+        };
+    }
+
+    public static string BuildObjectDdlRetrievalScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        return node.NodeType switch
+        {
+            NodeType.View => BuildViewDdlRetrievalQuery(connectionSettings, node),
+            NodeType.Procedure => BuildRoutineDdlRetrievalQuery(connectionSettings, node, isFunction: false),
+            NodeType.Function => BuildRoutineDdlRetrievalQuery(connectionSettings, node, isFunction: true),
+            _ => BuildQualifiedName(connectionSettings, node)
+        };
     }
 
     public static string BuildExecuteProcedureScript(IConnectionSettings connectionSettings, SchemaNode node)
@@ -118,6 +210,19 @@ public static class DatabaseObjectScriptBuilder
             .ToList();
     }
 
+    private static IReadOnlyList<ColumnModel> GetLoadedColumns(SchemaNode node)
+    {
+        var columnsFolder = node.Children.FirstOrDefault(child => child.NodeType == NodeType.Columns);
+        if (columnsFolder is null)
+            return [];
+
+        return columnsFolder.Children
+            .Select(child => child.Tag as ColumnModel)
+            .Where(column => column is not null)
+            .Cast<ColumnModel>()
+            .ToList();
+    }
+
     private static bool IsInvocationParameter(RoutineParameterModel parameter)
     {
         return !string.Equals(parameter.Name, "@RETURN_VALUE", StringComparison.OrdinalIgnoreCase) &&
@@ -154,5 +259,416 @@ public static class DatabaseObjectScriptBuilder
     {
         var argumentList = string.Join(", ", parameters.Select(parameter => parameter.Name));
         return $"call {qualifiedName}({argumentList});";
+    }
+
+    private static string BuildCreateTableScript(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        var qualifiedName = BuildQualifiedName(connectionSettings, node);
+        var columns = GetLoadedColumns(node);
+        if (columns.Count == 0)
+            return $"create table {qualifiedName}{Environment.NewLine}({Environment.NewLine}    -- load columns to generate DDL{Environment.NewLine});";
+
+        var lines = columns
+            .Select(column => $"    {QuoteSingleIdentifier(connectionSettings, column.Name)} {BuildColumnType(column)} {(column.IsNullable ? "null" : "not null")}")
+            .ToList();
+
+        var primaryKeys = columns.Where(column => column.IsPrimaryKey).ToList();
+        if (primaryKeys.Count > 0)
+        {
+            var pkColumns = string.Join(", ", primaryKeys.Select(column => QuoteSingleIdentifier(connectionSettings, column.Name)));
+            lines.Add($"    primary key ({pkColumns})");
+        }
+
+        return $"create table {qualifiedName}{Environment.NewLine}({Environment.NewLine}{string.Join($",{Environment.NewLine}", lines)}{Environment.NewLine});";
+    }
+
+    private static string BuildColumnType(ColumnModel column)
+    {
+        var dataType = column.DataType;
+        if (column.Length != 0 &&
+            dataType is "varchar" or "nvarchar" or "char" or "nchar" or "varbinary" or "binary")
+        {
+            return $"{dataType}({(column.Length == -1 ? "max" : column.Length)})";
+        }
+
+        if (dataType.Contains("date", StringComparison.OrdinalIgnoreCase) ||
+            dataType.Contains("time", StringComparison.OrdinalIgnoreCase))
+        {
+            return dataType;
+        }
+
+        if (column.Precision != 0)
+        {
+            return column.Scale != 0
+                ? $"{dataType}({column.Precision}, {column.Scale})"
+                : $"{dataType}({column.Precision})";
+        }
+
+        return dataType;
+    }
+
+    private static string BuildRoutineDdlRetrievalQuery(IConnectionSettings connectionSettings, SchemaNode node, bool isFunction)
+    {
+        var objectName = BuildQualifiedName(connectionSettings, node);
+        var (schemaName, routineName) = SplitQualifiedObjectName(node.Name);
+
+        return connectionSettings.DatabaseType switch
+        {
+            DatabaseType.SqlServer => $"select object_definition(object_id(N'{EscapeSqlLiteral(node.Name)}')) as Definition;",
+            DatabaseType.MySql => $"show create {(isFunction ? "function" : "procedure")} {objectName};",
+            DatabaseType.PostgresSql => BuildPostgresRoutineDdlScript(schemaName, routineName),
+            _ => objectName
+        };
+    }
+
+    private static string? BuildTableDdlRetrievalQuery(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        var objectName = BuildQualifiedName(connectionSettings, node);
+        var escapedObjectName = EscapeSqlLiteral(node.Name);
+        var (schemaName, tableName) = SplitQualifiedObjectName(node.Name);
+        return connectionSettings.DatabaseType switch
+        {
+            DatabaseType.MySql => $"show create table {objectName};",
+            DatabaseType.SqlServer => BuildSqlServerTableDdlRetrievalQuery(escapedObjectName),
+            DatabaseType.PostgresSql => BuildPostgresTableDdlRetrievalQuery(schemaName, tableName),
+            _ => null
+        };
+    }
+
+    private static string BuildSqlServerTableDdlRetrievalQuery(string objectName)
+    {
+        return
+            "declare @ObjectId int = object_id(N'" + objectName + "');" + Environment.NewLine +
+            "if @ObjectId is null" + Environment.NewLine +
+            "begin" + Environment.NewLine +
+            "    select cast(null as nvarchar(max)) as Definition;" + Environment.NewLine +
+            "    return;" + Environment.NewLine +
+            "end;" + Environment.NewLine +
+            Environment.NewLine +
+            "select" + Environment.NewLine +
+            "    'create table ' + quotename(s.name) + '.' + quotename(t.name) + char(13) + '(' + char(13) +" + Environment.NewLine +
+            "    stuff((" + Environment.NewLine +
+            "        select" + Environment.NewLine +
+            "            ',' + char(13) + '    ' + quotename(c.name) + ' ' +" + Environment.NewLine +
+            "            case" + Environment.NewLine +
+            "                when cc.object_id is not null then 'as ' + cc.definition" + Environment.NewLine +
+            "                when ty.name in ('varchar', 'char', 'varbinary', 'binary')" + Environment.NewLine +
+            "                    then ty.name + '(' + case when c.max_length = -1 then 'max' else cast(c.max_length as varchar(10)) end + ')'" + Environment.NewLine +
+            "                when ty.name in ('nvarchar', 'nchar')" + Environment.NewLine +
+            "                    then ty.name + '(' + case when c.max_length = -1 then 'max' else cast(c.max_length / 2 as varchar(10)) end + ')'" + Environment.NewLine +
+            "                when ty.name in ('decimal', 'numeric')" + Environment.NewLine +
+            "                    then ty.name + '(' + cast(c.precision as varchar(10)) + ', ' + cast(c.scale as varchar(10)) + ')'" + Environment.NewLine +
+            "                when ty.name in ('datetime2', 'datetimeoffset', 'time')" + Environment.NewLine +
+            "                    then ty.name + '(' + cast(c.scale as varchar(10)) + ')'" + Environment.NewLine +
+            "                else ty.name" + Environment.NewLine +
+            "            end +" + Environment.NewLine +
+            "            case" + Environment.NewLine +
+            "                when cc.object_id is not null then ''" + Environment.NewLine +
+            "                when ic.object_id is not null" + Environment.NewLine +
+            "                    then ' identity(' + cast(convert(bigint, ic.seed_value) as varchar(30)) + ', ' + cast(convert(bigint, ic.increment_value) as varchar(30)) + ')'" + Environment.NewLine +
+            "                else ''" + Environment.NewLine +
+            "            end +" + Environment.NewLine +
+            "            case" + Environment.NewLine +
+            "                when cc.object_id is not null then ''" + Environment.NewLine +
+            "                when c.is_rowguidcol = 1 then ' rowguidcol'" + Environment.NewLine +
+            "                else ''" + Environment.NewLine +
+            "            end +" + Environment.NewLine +
+            "            case when c.is_nullable = 1 then ' null' else ' not null' end +" + Environment.NewLine +
+            "            case" + Environment.NewLine +
+            "                when cc.object_id is not null then ''" + Environment.NewLine +
+            "                else coalesce(' default ' + dc.definition, '')" + Environment.NewLine +
+            "            end" + Environment.NewLine +
+            "        from sys.columns c" + Environment.NewLine +
+            "        join sys.types ty on ty.user_type_id = c.user_type_id" + Environment.NewLine +
+            "        left join sys.computed_columns cc on cc.object_id = c.object_id and cc.column_id = c.column_id" + Environment.NewLine +
+            "        left join sys.identity_columns ic on ic.object_id = c.object_id and ic.column_id = c.column_id" + Environment.NewLine +
+            "        left join sys.default_constraints dc on dc.parent_object_id = c.object_id and dc.parent_column_id = c.column_id" + Environment.NewLine +
+            "        where c.object_id = t.object_id" + Environment.NewLine +
+            "        order by c.column_id" + Environment.NewLine +
+            "        for xml path(''), type).value('.', 'nvarchar(max)'), 1, 3, '    ') +" + Environment.NewLine +
+            "    coalesce((" + Environment.NewLine +
+            "        select char(13) + ',' + char(13) + '    constraint ' + quotename(kc.name) + ' primary key ' +" + Environment.NewLine +
+            "               case when i.type = 1 then 'clustered' else 'nonclustered' end +" + Environment.NewLine +
+            "               ' (' +" + Environment.NewLine +
+            "               stuff((" + Environment.NewLine +
+            "                    select ', ' + quotename(c.name)" + Environment.NewLine +
+            "                    from sys.index_columns ic2" + Environment.NewLine +
+            "                    join sys.columns c on c.object_id = ic2.object_id and c.column_id = ic2.column_id" + Environment.NewLine +
+            "                    where ic2.object_id = i.object_id and ic2.index_id = i.index_id and ic2.key_ordinal > 0" + Environment.NewLine +
+            "                    order by ic2.key_ordinal" + Environment.NewLine +
+            "                    for xml path(''), type).value('.', 'nvarchar(max)'), 1, 2, '') +" + Environment.NewLine +
+            "               ')'" + Environment.NewLine +
+            "        from sys.key_constraints kc" + Environment.NewLine +
+            "        join sys.indexes i on i.object_id = kc.parent_object_id and i.index_id = kc.unique_index_id" + Environment.NewLine +
+            "        where kc.parent_object_id = t.object_id and kc.type = 'PK'" + Environment.NewLine +
+            "    ), '') +" + Environment.NewLine +
+            "    coalesce((" + Environment.NewLine +
+            "        select" + Environment.NewLine +
+            "            (" + Environment.NewLine +
+            "                select char(13) + ',' + char(13) + '    constraint ' + quotename(kc.name) + ' unique ' +" + Environment.NewLine +
+            "                       case when i.type = 1 then 'clustered' else 'nonclustered' end +" + Environment.NewLine +
+            "                       ' (' +" + Environment.NewLine +
+            "                       stuff((" + Environment.NewLine +
+            "                            select ', ' + quotename(c.name)" + Environment.NewLine +
+            "                            from sys.index_columns ic2" + Environment.NewLine +
+            "                            join sys.columns c on c.object_id = ic2.object_id and c.column_id = ic2.column_id" + Environment.NewLine +
+            "                            where ic2.object_id = i.object_id and ic2.index_id = i.index_id and ic2.key_ordinal > 0" + Environment.NewLine +
+            "                            order by ic2.key_ordinal" + Environment.NewLine +
+            "                            for xml path(''), type).value('.', 'nvarchar(max)'), 1, 2, '') +" + Environment.NewLine +
+            "                       ')'" + Environment.NewLine +
+            "                from sys.key_constraints kc" + Environment.NewLine +
+            "                join sys.indexes i on i.object_id = kc.parent_object_id and i.index_id = kc.unique_index_id" + Environment.NewLine +
+            "                where kc.parent_object_id = t.object_id and kc.type = 'UQ'" + Environment.NewLine +
+            "                for xml path(''), type" + Environment.NewLine +
+            "            ).value('.', 'nvarchar(max)')" + Environment.NewLine +
+            "    ), '') +" + Environment.NewLine +
+            "    coalesce((" + Environment.NewLine +
+            "        select" + Environment.NewLine +
+            "            (" + Environment.NewLine +
+            "                select char(13) + ',' + char(13) + '    constraint ' + quotename(cc.name) + ' check ' + cc.definition" + Environment.NewLine +
+            "                from sys.check_constraints cc" + Environment.NewLine +
+            "                where cc.parent_object_id = t.object_id" + Environment.NewLine +
+            "                for xml path(''), type" + Environment.NewLine +
+            "            ).value('.', 'nvarchar(max)')" + Environment.NewLine +
+            "    ), '') +" + Environment.NewLine +
+            "    coalesce((" + Environment.NewLine +
+            "        select" + Environment.NewLine +
+            "            (" + Environment.NewLine +
+            "                select char(13) + ',' + char(13) + '    constraint ' + quotename(fk.name) + ' foreign key (' +" + Environment.NewLine +
+            "                       stuff((" + Environment.NewLine +
+            "                            select ', ' + quotename(pc.name)" + Environment.NewLine +
+            "                            from sys.foreign_key_columns fkc2" + Environment.NewLine +
+            "                            join sys.columns pc on pc.object_id = fkc2.parent_object_id and pc.column_id = fkc2.parent_column_id" + Environment.NewLine +
+            "                            where fkc2.constraint_object_id = fk.object_id" + Environment.NewLine +
+            "                            order by fkc2.constraint_column_id" + Environment.NewLine +
+            "                            for xml path(''), type).value('.', 'nvarchar(max)'), 1, 2, '') +" + Environment.NewLine +
+            "                       ') references ' + quotename(rs.name) + '.' + quotename(rt.name) + ' (' +" + Environment.NewLine +
+            "                       stuff((" + Environment.NewLine +
+            "                            select ', ' + quotename(rc.name)" + Environment.NewLine +
+            "                            from sys.foreign_key_columns fkc3" + Environment.NewLine +
+            "                            join sys.columns rc on rc.object_id = fkc3.referenced_object_id and rc.column_id = fkc3.referenced_column_id" + Environment.NewLine +
+            "                            where fkc3.constraint_object_id = fk.object_id" + Environment.NewLine +
+            "                            order by fkc3.constraint_column_id" + Environment.NewLine +
+            "                            for xml path(''), type).value('.', 'nvarchar(max)'), 1, 2, '') +" + Environment.NewLine +
+            "                       ')' +" + Environment.NewLine +
+            "                       case fk.delete_referential_action" + Environment.NewLine +
+            "                            when 1 then ' on delete cascade'" + Environment.NewLine +
+            "                            when 2 then ' on delete set null'" + Environment.NewLine +
+            "                            when 3 then ' on delete set default'" + Environment.NewLine +
+            "                            else ''" + Environment.NewLine +
+            "                       end +" + Environment.NewLine +
+            "                       case fk.update_referential_action" + Environment.NewLine +
+            "                            when 1 then ' on update cascade'" + Environment.NewLine +
+            "                            when 2 then ' on update set null'" + Environment.NewLine +
+            "                            when 3 then ' on update set default'" + Environment.NewLine +
+            "                            else ''" + Environment.NewLine +
+            "                       end" + Environment.NewLine +
+            "                from sys.foreign_keys fk" + Environment.NewLine +
+            "                join sys.tables rt on rt.object_id = fk.referenced_object_id" + Environment.NewLine +
+            "                join sys.schemas rs on rs.schema_id = rt.schema_id" + Environment.NewLine +
+            "                where fk.parent_object_id = t.object_id" + Environment.NewLine +
+            "                for xml path(''), type" + Environment.NewLine +
+            "            ).value('.', 'nvarchar(max)')" + Environment.NewLine +
+            "    ), '') +" + Environment.NewLine +
+            "    char(13) + ');' as Definition" + Environment.NewLine +
+            "from sys.tables t" + Environment.NewLine +
+            "join sys.schemas s on s.schema_id = t.schema_id" + Environment.NewLine +
+            "where t.object_id = @ObjectId;" + Environment.NewLine +
+            Environment.NewLine +
+            "select" + Environment.NewLine +
+            "    'create ' +" + Environment.NewLine +
+            "    case when i.is_unique = 1 then 'unique ' else '' end +" + Environment.NewLine +
+            "    case when i.type = 1 then 'clustered ' when i.type = 2 then 'nonclustered ' else '' end +" + Environment.NewLine +
+            "    'index ' + quotename(i.name) + ' on ' + quotename(s.name) + '.' + quotename(t.name) + ' (' +" + Environment.NewLine +
+            "    stuff((" + Environment.NewLine +
+            "        select ', ' + quotename(c.name) + case when ic.is_descending_key = 1 then ' desc' else ' asc' end" + Environment.NewLine +
+            "        from sys.index_columns ic" + Environment.NewLine +
+            "        join sys.columns c on c.object_id = ic.object_id and c.column_id = ic.column_id" + Environment.NewLine +
+            "        where ic.object_id = i.object_id and ic.index_id = i.index_id and ic.key_ordinal > 0" + Environment.NewLine +
+            "        order by ic.key_ordinal" + Environment.NewLine +
+            "        for xml path(''), type).value('.', 'nvarchar(max)'), 1, 2, '') +" + Environment.NewLine +
+            "    ')' +" + Environment.NewLine +
+            "    case when exists (" + Environment.NewLine +
+            "            select 1" + Environment.NewLine +
+            "            from sys.index_columns ic" + Environment.NewLine +
+            "            where ic.object_id = i.object_id and ic.index_id = i.index_id and ic.is_included_column = 1" + Environment.NewLine +
+            "        ) then ' include (' +" + Environment.NewLine +
+            "            stuff((" + Environment.NewLine +
+            "                select ', ' + quotename(c.name)" + Environment.NewLine +
+            "                from sys.index_columns ic" + Environment.NewLine +
+            "                join sys.columns c on c.object_id = ic.object_id and c.column_id = ic.column_id" + Environment.NewLine +
+            "                where ic.object_id = i.object_id and ic.index_id = i.index_id and ic.is_included_column = 1" + Environment.NewLine +
+            "                order by ic.index_column_id" + Environment.NewLine +
+            "                for xml path(''), type).value('.', 'nvarchar(max)'), 1, 2, '') +" + Environment.NewLine +
+            "            ')' else '' end +" + Environment.NewLine +
+            "    ';' as Definition" + Environment.NewLine +
+            "from sys.indexes i" + Environment.NewLine +
+            "join sys.tables t on t.object_id = i.object_id" + Environment.NewLine +
+            "join sys.schemas s on s.schema_id = t.schema_id" + Environment.NewLine +
+            "where i.object_id = @ObjectId" + Environment.NewLine +
+            "  and i.is_hypothetical = 0" + Environment.NewLine +
+            "  and i.type in (1, 2)" + Environment.NewLine +
+            "  and i.is_primary_key = 0" + Environment.NewLine +
+            "  and i.is_unique_constraint = 0;";
+    }
+
+    private static string BuildPostgresTableDdlRetrievalQuery(string schemaName, string tableName)
+    {
+        var escapedSchemaName = EscapeSqlLiteral(schemaName);
+        var escapedTableName = EscapeSqlLiteral(tableName);
+
+        return
+            "with target_table as (" + Environment.NewLine +
+            "    select c.oid, n.nspname as schema_name, c.relname as table_name" + Environment.NewLine +
+            "    from pg_class c" + Environment.NewLine +
+            "    join pg_namespace n on n.oid = c.relnamespace" + Environment.NewLine +
+            $"    where n.nspname = '{escapedSchemaName}'" + Environment.NewLine +
+            $"      and c.relname = '{escapedTableName}'" + Environment.NewLine +
+            "      and c.relkind in ('r', 'p')" + Environment.NewLine +
+            "), column_data as (" + Environment.NewLine +
+            "    select" + Environment.NewLine +
+            "        a.attrelid," + Environment.NewLine +
+            "        a.attnum," + Environment.NewLine +
+            "        a.attname," + Environment.NewLine +
+            "        a.attnotnull," + Environment.NewLine +
+            "        a.attidentity," + Environment.NewLine +
+            "        a.attgenerated," + Environment.NewLine +
+            "        format_type(a.atttypid, a.atttypmod) as formatted_type," + Environment.NewLine +
+            "        pg_get_expr(ad.adbin, ad.adrelid) as default_expr," + Environment.NewLine +
+            "        replace(replace(replace(format_type(a.atttypid, a.atttypmod), 'character varying', 'varchar'), 'timestamp without time zone', 'timestamp'), 'time without time zone', 'time') as display_type," + Environment.NewLine +
+            "        pg_get_serial_sequence(format('%I.%I', tt.schema_name, tt.table_name), a.attname) as serial_sequence," + Environment.NewLine +
+            "        (" + Environment.NewLine +
+            "            a.attidentity = '' and" + Environment.NewLine +
+            "            a.attgenerated = '' and" + Environment.NewLine +
+            "            pg_get_serial_sequence(format('%I.%I', tt.schema_name, tt.table_name), a.attname) is not null and" + Environment.NewLine +
+            "            pg_get_expr(ad.adbin, ad.adrelid) = 'nextval(''' || pg_get_serial_sequence(format('%I.%I', tt.schema_name, tt.table_name), a.attname) || '''::regclass)'" + Environment.NewLine +
+            "        ) as is_schema_qualified_serial," + Environment.NewLine +
+            "        (" + Environment.NewLine +
+            "            a.attidentity = '' and" + Environment.NewLine +
+            "            a.attgenerated = '' and" + Environment.NewLine +
+            "            pg_get_serial_sequence(format('%I.%I', tt.schema_name, tt.table_name), a.attname) is not null and" + Environment.NewLine +
+            "            pg_get_expr(ad.adbin, ad.adrelid) = 'nextval(''' || split_part(pg_get_serial_sequence(format('%I.%I', tt.schema_name, tt.table_name), a.attname), '.', 2) || '''::regclass)'" + Environment.NewLine +
+            "        ) as is_unqualified_serial" + Environment.NewLine +
+            "    from target_table tt" + Environment.NewLine +
+            "    join pg_attribute a on a.attrelid = tt.oid" + Environment.NewLine +
+            "    left join pg_attrdef ad on ad.adrelid = a.attrelid and ad.adnum = a.attnum" + Environment.NewLine +
+            "    where a.attnum > 0" + Environment.NewLine +
+            "      and not a.attisdropped" + Environment.NewLine +
+            "), table_ddl as (" + Environment.NewLine +
+            "    select" + Environment.NewLine +
+            "        'create table ' || quote_ident(tt.schema_name) || '.' || quote_ident(tt.table_name) || E'\\n(' || E'\\n' ||" + Environment.NewLine +
+            "        (" + Environment.NewLine +
+            "            select string_agg(" + Environment.NewLine +
+            "                case when a.is_schema_qualified_serial or a.is_unqualified_serial then '    -- sequence: ' || a.serial_sequence || E'\\n' else '' end ||" + Environment.NewLine +
+            "                '    ' || quote_ident(a.attname) || ' ' ||" + Environment.NewLine +
+            "                case" + Environment.NewLine +
+            "                    when a.attidentity in ('a', 'd')" + Environment.NewLine +
+            "                        then a.display_type || ' generated ' ||" + Environment.NewLine +
+            "                             case a.attidentity when 'a' then 'always' else 'by default' end || ' as identity'" + Environment.NewLine +
+            "                    when a.is_schema_qualified_serial or a.is_unqualified_serial" + Environment.NewLine +
+            "                        then case a.formatted_type" + Environment.NewLine +
+            "                                when 'integer' then 'serial'" + Environment.NewLine +
+            "                                when 'bigint' then 'bigserial'" + Environment.NewLine +
+            "                                when 'smallint' then 'smallserial'" + Environment.NewLine +
+            "                                else a.display_type" + Environment.NewLine +
+            "                             end" + Environment.NewLine +
+            "                    else a.display_type" + Environment.NewLine +
+            "                end ||" + Environment.NewLine +
+            "                case when a.attgenerated = 's' then ' generated always as (' || a.default_expr || ') stored' else '' end ||" + Environment.NewLine +
+            "                case" + Environment.NewLine +
+            "                    when a.attgenerated <> '' or a.attidentity in ('a', 'd') then ''" + Environment.NewLine +
+            "                    when a.is_schema_qualified_serial or a.is_unqualified_serial then ''" + Environment.NewLine +
+            "                    when a.default_expr is not null then ' default ' || a.default_expr" + Environment.NewLine +
+            "                    else ''" + Environment.NewLine +
+            "                end ||" + Environment.NewLine +
+            "                case when a.attnotnull then ' not null' else '' end," + Environment.NewLine +
+            "                ',' || E'\\n' ORDER BY a.attnum" + Environment.NewLine +
+            "            )" + Environment.NewLine +
+            "            from column_data a" + Environment.NewLine +
+            "            where a.attrelid = tt.oid" + Environment.NewLine +
+            "        ) ||" + Environment.NewLine +
+            "        coalesce((" + Environment.NewLine +
+            "            select E',\\n' || string_agg('    constraint ' || quote_ident(con.conname) || ' ' || replace(replace(pg_get_constraintdef(con.oid, true), 'PRIMARY KEY', 'primary key'), 'FOREIGN KEY', 'foreign key'), E',\\n' ORDER BY con.conname)" + Environment.NewLine +
+            "            from pg_constraint con" + Environment.NewLine +
+            "            where con.conrelid = tt.oid" + Environment.NewLine +
+            "              and con.contype in ('p', 'u', 'f', 'c')" + Environment.NewLine +
+            "        ), '') || E'\\n);' as definition," + Environment.NewLine +
+            "        tt.oid" + Environment.NewLine +
+            "    from target_table tt" + Environment.NewLine +
+            "), index_ddl as (" + Environment.NewLine +
+            "    select pg_get_indexdef(i.indexrelid) || ';' as definition" + Environment.NewLine +
+            "    from target_table tt" + Environment.NewLine +
+            "    join pg_index i on i.indrelid = tt.oid" + Environment.NewLine +
+            "    join pg_class ic on ic.oid = i.indexrelid" + Environment.NewLine +
+            "    where not i.indisprimary" + Environment.NewLine +
+            "      and not exists (" + Environment.NewLine +
+            "          select 1" + Environment.NewLine +
+            "          from pg_constraint con" + Environment.NewLine +
+            "          where con.conrelid = tt.oid" + Environment.NewLine +
+            "            and con.conindid = i.indexrelid" + Environment.NewLine +
+            "      )" + Environment.NewLine +
+            "    order by ic.relname" + Environment.NewLine +
+            ")" + Environment.NewLine +
+            "select definition as Definition from table_ddl" + Environment.NewLine +
+            "union all" + Environment.NewLine +
+            "select definition as Definition from index_ddl;";
+    }
+
+    private static string BuildViewDdlRetrievalQuery(IConnectionSettings connectionSettings, SchemaNode node)
+    {
+        var objectName = BuildQualifiedName(connectionSettings, node);
+        var (schemaName, viewName) = SplitQualifiedObjectName(node.Name);
+
+        return connectionSettings.DatabaseType switch
+        {
+            DatabaseType.SqlServer => $"select object_definition(object_id(N'{EscapeSqlLiteral(node.Name)}')) as Definition;",
+            DatabaseType.MySql => $"show create view {objectName};",
+            DatabaseType.PostgresSql =>
+                "select 'create or replace view ' || quote_ident(n.nspname) || '.' || quote_ident(c.relname) || ' as' || E'\\n' || pg_get_viewdef(c.oid, true) as Definition" + Environment.NewLine +
+                "from pg_class c" + Environment.NewLine +
+                "join pg_namespace n on n.oid = c.relnamespace" + Environment.NewLine +
+                $"where n.nspname = '{EscapeSqlLiteral(schemaName)}'" + Environment.NewLine +
+                $"  and c.relname = '{EscapeSqlLiteral(viewName)}'" + Environment.NewLine +
+                "  and c.relkind = 'v';",
+            _ => objectName
+        };
+    }
+
+    private static string BuildPostgresRoutineDdlScript(string schemaName, string routineName)
+    {
+        return
+            $"select pg_get_functiondef(p.oid){Environment.NewLine}" +
+            "from pg_proc p" + Environment.NewLine +
+            "join pg_namespace n on n.oid = p.pronamespace" + Environment.NewLine +
+            $"where n.nspname = '{EscapeSqlLiteral(schemaName)}'" + Environment.NewLine +
+            $"  and p.proname = '{EscapeSqlLiteral(routineName)}';";
+    }
+
+    private static (string SchemaName, string ObjectName) SplitQualifiedObjectName(string objectName)
+    {
+        var parts = objectName
+            .Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToArray();
+
+        return parts.Length switch
+        {
+            >= 2 => (NormalizeIdentifier(parts[^2]), NormalizeIdentifier(parts[^1])),
+            _ => ("public", NormalizeIdentifier(objectName))
+        };
+    }
+
+    private static string NormalizeIdentifier(string identifier)
+    {
+        return identifier.Trim().Trim('[', ']', '`', '"');
+    }
+
+    private static string EscapeSqlLiteral(string value)
+    {
+        return value.Replace("'", "''", StringComparison.Ordinal);
+    }
+
+    private static string FormatValuePlaceholder(string columnName)
+    {
+        return $"@{NormalizeIdentifier(columnName)}";
     }
 }

--- a/DataDeveloper/Services/SqlParameterDetector.cs
+++ b/DataDeveloper/Services/SqlParameterDetector.cs
@@ -7,6 +7,9 @@ namespace DataDeveloper.Services;
 
 public static class SqlParameterDetector
 {
+    private static readonly Regex RoutineDeclarationRegex = new(
+        @"(?ix)\b(?:(?:create\s+or\s+alter)|create|alter)\s+(?<kind>procedure|function)\b",
+        RegexOptions.Compiled);
     private static readonly Regex DeclaredParameterRegex = new(
         @"\bdeclare\s+(?<parameter>@[A-Za-z_][A-Za-z0-9_]*)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -304,11 +307,12 @@ public static class SqlParameterDetector
 
         while (searchIndex < lowerSql.Length)
         {
-            var declarationStart = FindNextRoutineDeclaration(lowerSql, searchIndex);
-            if (declarationStart < 0)
+            var declarationMatch = FindNextRoutineDeclaration(lowerSql, searchIndex);
+            if (declarationMatch is null)
                 break;
 
-            var declarationHeaderEnd = FindDeclarationHeaderEnd(lowerSql, declarationStart);
+            var declarationStart = declarationMatch.Index;
+            var declarationHeaderEnd = FindDeclarationHeaderEnd(declarationMatch);
             if (declarationHeaderEnd < 0)
                 break;
 
@@ -316,50 +320,32 @@ public static class SqlParameterDetector
             if (declarationBodyStart < 0)
                 break;
 
-            for (var i = declarationHeaderEnd; i < declarationBodyStart; i++)
+            var declarationEnd = FindRoutineDeclarationEnd(lowerSql, declarationBodyStart);
+            if (declarationEnd < 0)
+                declarationEnd = lowerSql.Length;
+
+            for (var i = declarationStart; i < declarationEnd; i++)
                 builder[i] = ' ';
 
-            searchIndex = declarationBodyStart;
+            searchIndex = declarationEnd;
         }
 
         return builder.ToString();
     }
 
-    private static int FindNextRoutineDeclaration(string sql, int startIndex)
+    private static Match? FindNextRoutineDeclaration(string sql, int startIndex)
     {
-        var candidates = new[]
-        {
-            "create procedure",
-            "alter procedure",
-            "create function",
-            "alter function",
-            "create or alter procedure",
-            "create or alter function"
-        };
-
-        var next = -1;
-        foreach (var candidate in candidates)
-        {
-            var index = sql.IndexOf(candidate, startIndex, StringComparison.Ordinal);
-            if (index >= 0 && (next < 0 || index < next))
-                next = index;
-        }
-
-        return next;
+        var match = RoutineDeclarationRegex.Match(sql, startIndex);
+        return match.Success ? match : null;
     }
 
-    private static int FindDeclarationHeaderEnd(string sql, int declarationStart)
+    private static int FindDeclarationHeaderEnd(Match declarationMatch)
     {
-        var procedureIndex = sql.IndexOf("procedure", declarationStart, StringComparison.Ordinal);
-        var functionIndex = sql.IndexOf("function", declarationStart, StringComparison.Ordinal);
-        var keywordIndex = procedureIndex >= 0 && (functionIndex < 0 || procedureIndex < functionIndex)
-            ? procedureIndex
-            : functionIndex;
-
-        if (keywordIndex < 0)
+        var kindGroup = declarationMatch.Groups["kind"];
+        if (!kindGroup.Success)
             return -1;
 
-        return keywordIndex + (procedureIndex == keywordIndex ? "procedure".Length : "function".Length);
+        return kindGroup.Index + kindGroup.Length;
     }
 
     private static int FindDeclarationBodyStart(string sql, int startIndex)
@@ -392,6 +378,109 @@ public static class SqlParameterDetector
         }
 
         return -1;
+    }
+
+    private static int FindRoutineDeclarationEnd(string sql, int bodyStartIndex)
+    {
+        var batchSeparatorIndex = FindNextBatchSeparator(sql, bodyStartIndex);
+        var bodyEndIndex = FindRoutineBodyEnd(sql, bodyStartIndex);
+
+        if (batchSeparatorIndex >= 0 && bodyEndIndex >= 0)
+            return Math.Min(batchSeparatorIndex, bodyEndIndex);
+
+        return batchSeparatorIndex >= 0 ? batchSeparatorIndex : bodyEndIndex;
+    }
+
+    private static int FindNextBatchSeparator(string sql, int startIndex)
+    {
+        var index = startIndex;
+        while (index < sql.Length)
+        {
+            var lineStart = index;
+            while (lineStart < sql.Length && (sql[lineStart] == '\r' || sql[lineStart] == '\n'))
+                lineStart++;
+
+            if (lineStart >= sql.Length)
+                return -1;
+
+            var lineEnd = lineStart;
+            while (lineEnd < sql.Length && sql[lineEnd] != '\r' && sql[lineEnd] != '\n')
+                lineEnd++;
+
+            var line = sql[lineStart..lineEnd].Trim();
+            if (string.Equals(line, "go", StringComparison.OrdinalIgnoreCase))
+                return lineStart;
+
+            index = lineEnd + 1;
+        }
+
+        return -1;
+    }
+
+    private static int FindRoutineBodyEnd(string sql, int bodyStartIndex)
+    {
+        var index = bodyStartIndex;
+        var beginDepth = 0;
+        var sawBegin = false;
+
+        while (index < sql.Length)
+        {
+            if (sql[index] == '\'' || sql[index] == '"')
+            {
+                index = SkipQuotedString(sql, index, sql[index]);
+                continue;
+            }
+
+            if (sql[index] == '-' && index + 1 < sql.Length && sql[index + 1] == '-')
+            {
+                index = SkipSingleLineComment(sql, index);
+                continue;
+            }
+
+            if (sql[index] == '/' && index + 1 < sql.Length && sql[index + 1] == '*')
+            {
+                index = SkipMultiLineComment(sql, index);
+                continue;
+            }
+
+            if (IsKeywordAt(sql, index, "begin"))
+            {
+                beginDepth++;
+                sawBegin = true;
+                index += "begin".Length;
+                continue;
+            }
+
+            if (IsKeywordAt(sql, index, "end"))
+            {
+                if (beginDepth > 0)
+                {
+                    beginDepth--;
+                    index += "end".Length;
+                    if (sawBegin && beginDepth == 0)
+                        return ConsumeStatementTerminator(sql, index);
+                    continue;
+                }
+            }
+
+            if (!sawBegin && sql[index] == ';')
+                return index + 1;
+
+            index++;
+        }
+
+        return sql.Length;
+    }
+
+    private static int ConsumeStatementTerminator(string sql, int index)
+    {
+        while (index < sql.Length && char.IsWhiteSpace(sql[index]))
+            index++;
+
+        if (index < sql.Length && sql[index] == ';')
+            return index + 1;
+
+        return index;
     }
 
     private static bool IsKeywordAt(string sql, int index, string keyword)

--- a/DataDeveloper/ViewModels/TabConnectionViewModel.cs
+++ b/DataDeveloper/ViewModels/TabConnectionViewModel.cs
@@ -4,12 +4,14 @@ using System.IO;
 using System.Reactive;
 using System.Threading.Tasks;
 using DataDeveloper.Data;
+using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Interfaces;
 using DataDeveloper.Data.Models;
+using DataDeveloper.Data.Services;
 using DataDeveloper.Enums;
+using DataDeveloper.EventAggregators;
 using DataDeveloper.Interfaces;
 using DataDeveloper.Models;
-using DataDeveloper.Data.Enums;
 using DataDeveloper.Views;
 using DynamicData;
 using ReactiveUI;
@@ -22,6 +24,7 @@ public class TabConnectionViewModel : BaseTabContent
 {
     private int _countQueryEditors = 0;
     private readonly IDialogService _dialogService;
+    private readonly IEventAggregatorService _eventAggregatorService;
     
     public TabConnectionViewModel(IConnectionSettings connectionSettings, bool canClose, IServiceProvider serviceProvider) 
         : base(TabType.Connection, connectionSettings.Name, canClose, serviceProvider)
@@ -29,6 +32,7 @@ public class TabConnectionViewModel : BaseTabContent
         ConnectionSettings = connectionSettings;    
         SchemaExplorer = ConnectionSettings.GetSchemaExplorer();
         _dialogService = ServiceProvider.GetRequiredService<IDialogService>();
+        _eventAggregatorService = ServiceProvider.GetRequiredService<IEventAggregatorService>();
         
         this.Initialization = LoadConnection();
 
@@ -42,11 +46,65 @@ public class TabConnectionViewModel : BaseTabContent
             
             QueryEditors[this.SelectedEditor].ShowCursorData();
         });
+
+        _eventAggregatorService.Subscribe<RefreshSchemaExplorerEvent>(
+            this,
+            async message =>
+            {
+                if (!string.IsNullOrWhiteSpace(message.Statement))
+                    await SchemaExplorer.RefreshSchemaObjectAsync(message.Statement);
+                else
+                    await SchemaExplorer.RefreshSchemaAsync();
+            },
+            message => message.ConnectionId == ConnectionSettings.Id);
     }
 
     private async Task Refresh()
     {
         await LoadConnection();
+    }
+
+    public async Task ExecuteBackgroundStatementAsync(string statement, bool refreshSchema = false)
+    {
+        try
+        {
+            await using var connection = ConnectionSettings.GetDatabaseProvider().GetConnection();
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = statement;
+            await command.ExecuteNonQueryAsync();
+
+            if (refreshSchema || StatementExecutionClassifier.RequiresSchemaRefresh(statement))
+                await SchemaExplorer.RefreshSchemaObjectAsync(statement);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowMessageAsync(ex.Message, "Execution error");
+        }
+    }
+
+    public async Task<bool> ConfirmDropAsync(SchemaNode node)
+    {
+        var objectType = node.NodeType switch
+        {
+            NodeType.Table => "table",
+            NodeType.View => "view",
+            NodeType.Procedure => "procedure",
+            NodeType.Function => "function",
+            _ => null
+        };
+
+        if (objectType is null)
+            return false;
+
+        var message = $"Are you sure you want to drop the {objectType} {node.Name}?";
+        var result = await _dialogService.ShowDialogAsync(
+            message,
+            "Confirm drop",
+            DialogButtons.YesNo,
+            DialogIcon.Warning);
+
+        return result == DialogResult.Yes;
     }
 
     public async Task<bool> SaveChanges(TabQueryEditorViewModel tabQueryEditor, bool isSaveAs = false)

--- a/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
+++ b/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DataDeveloper.Data;
 using DataDeveloper.Data.Interfaces;
+using DataDeveloper.Data.Services;
 using DataDeveloper.Enums;
 using DataDeveloper.EventAggregators;
 using DataDeveloper.Interfaces;
@@ -145,6 +146,7 @@ public class TabQueryEditorViewModel : BaseTabContent
                 Tabs.Remove(previousTab);
 
             var statementResults = (await statementExecutor.ExecuteStatement(statementToExecute, parameterValues)).ToList();
+            var shouldRefreshSchema = statementResults.Any(result => StatementExecutionClassifier.RequiresSchemaRefresh(result.Statement));
 
             if (statementResults.Any())
             {
@@ -159,7 +161,7 @@ public class TabQueryEditorViewModel : BaseTabContent
                     statementResult.Watcher.Start();
                     statementCount++;
 
-                    var hasDataReader = statementResult.HasDataReader;
+                    var hasDataReader = statementResult.HasResultSet;
 
                     var resultName = $"result {statementCount:00}";
                     
@@ -188,6 +190,15 @@ public class TabQueryEditorViewModel : BaseTabContent
                     statementResult.Watcher.Stop();
                 }
                 _eventAggregatorService.Publish(new ShowResultMessageEvent(this.Id, resultMessage.ToString()));
+            }
+
+            if (shouldRefreshSchema)
+            {
+                var ddlStatement = statementResults
+                    .Select(result => result.Statement)
+                    .FirstOrDefault(StatementExecutionClassifier.RequiresSchemaRefresh);
+
+                _eventAggregatorService.Publish(new RefreshSchemaExplorerEvent(ConnectionSettings.Id, ddlStatement));
             }
         }
         catch (Exception ex)

--- a/DataDeveloper/Views/TabConnectionView.axaml
+++ b/DataDeveloper/Views/TabConnectionView.axaml
@@ -84,6 +84,7 @@
                     <Style Selector="TreeViewItem">
                         <Setter Property="behaviors:TreeViewExpansionBehavior.MonitorExpansion" Value="True" />
                         <Setter Property="behaviors:TreeViewExpansionBehavior.SchemaExplorer" Value="{Binding DataContext.SchemaExplorer, RelativeSource={RelativeSource AncestorType=TreeView}}" />
+                        <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}" />
                         <Setter Property="Padding" Value="0" />
                         <Setter Property="Margin" Value="0" />
                         <Setter Property="MinHeight" Value="20" />

--- a/DataDeveloper/Views/TabConnectionView.axaml.cs
+++ b/DataDeveloper/Views/TabConnectionView.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data.Common;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using Avalonia.Controls;
 using Avalonia;
 using Avalonia.Input;
 using Avalonia.Media;
+using DataDeveloper.Data;
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Services;
@@ -105,6 +107,7 @@ public partial class TabConnectionView : UserControl
             return null;
 
         var items = new List<object>();
+        var sqlScriptItems = new List<object>();
 
         if (node.NodeType is NodeType.Table or NodeType.View or NodeType.Procedure or NodeType.Function or NodeType.Column or NodeType.Parameter)
         {
@@ -115,43 +118,125 @@ public partial class TabConnectionView : UserControl
 
         if (node.NodeType is NodeType.Table or NodeType.View)
         {
-            if (items.Count > 0)
-                items.Add(new Separator());
-
-            items.Add(CreateMenuItem("Open select script", () =>
+            sqlScriptItems.Add(CreateMenuItem("Select rows", () =>
             {
                 viewModel.OpenQueryEditorWithScript(DatabaseObjectScriptBuilder.BuildSelectRowsScript(viewModel.ConnectionSettings, node));
                 return Task.CompletedTask;
             }));
 
-            items.Add(CreateMenuItem("Open count script", () =>
+            sqlScriptItems.Add(CreateMenuItem("Count rows", () =>
             {
                 viewModel.OpenQueryEditorWithScript(DatabaseObjectScriptBuilder.BuildCountRowsScript(viewModel.ConnectionSettings, node));
                 return Task.CompletedTask;
             }));
         }
 
+        if (node.NodeType == NodeType.Table)
+        {
+            sqlScriptItems.Add(new Separator());
+            sqlScriptItems.Add(CreateMenuItem("Insert", async () =>
+            {
+                await EnsureTableColumnsLoadedAsync(node, viewModel);
+                viewModel.OpenQueryEditorWithScript(DatabaseObjectScriptBuilder.BuildInsertScript(viewModel.ConnectionSettings, node));
+            }));
+
+            sqlScriptItems.Add(CreateMenuItem("Update", async () =>
+            {
+                await EnsureTableColumnsLoadedAsync(node, viewModel);
+                viewModel.OpenQueryEditorWithScript(DatabaseObjectScriptBuilder.BuildUpdateScript(viewModel.ConnectionSettings, node));
+            }));
+
+            sqlScriptItems.Add(CreateMenuItem("Delete", async () =>
+            {
+                await EnsureTableColumnsLoadedAsync(node, viewModel);
+                viewModel.OpenQueryEditorWithScript(DatabaseObjectScriptBuilder.BuildDeleteScript(viewModel.ConnectionSettings, node));
+            }));
+
+            sqlScriptItems.Add(new Separator());
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to new Query", async () =>
+            {
+                await OpenTableDdlAsync(node, viewModel, openInEditor: true);
+            }));
+
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to clipboard", async () =>
+            {
+                await OpenTableDdlAsync(node, viewModel, openInEditor: false);
+            }));
+        }
+
+        if (node.NodeType == NodeType.View)
+        {
+            sqlScriptItems.Add(new Separator());
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to new Query", async () =>
+            {
+                await OpenDatabaseDdlAsync(node, viewModel, openInEditor: true);
+            }));
+
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to clipboard", async () =>
+            {
+                await OpenDatabaseDdlAsync(node, viewModel, openInEditor: false);
+            }));
+        }
+
         if (node.NodeType == NodeType.Procedure)
         {
-            if (items.Count > 0)
-                items.Add(new Separator());
-
-            items.Add(CreateMenuItem("Open execute script", async () =>
+            sqlScriptItems.Add(CreateMenuItem("Execute procedure...", async () =>
             {
                 await EnsureRoutineParametersLoadedAsync(node, viewModel);
                 viewModel.OpenQueryEditorWithScript(DatabaseObjectScriptBuilder.BuildExecuteProcedureScript(viewModel.ConnectionSettings, node));
+            }));
+
+            sqlScriptItems.Add(new Separator());
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to new Query", async () =>
+            {
+                await OpenDatabaseDdlAsync(node, viewModel, openInEditor: true);
+            }));
+
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to clipboard", async () =>
+            {
+                await OpenDatabaseDdlAsync(node, viewModel, openInEditor: false);
             }));
         }
 
         if (node.NodeType == NodeType.Function)
         {
-            if (items.Count > 0)
-                items.Add(new Separator());
-
-            items.Add(CreateMenuItem("Open select function script", async () =>
+            sqlScriptItems.Add(CreateMenuItem("Execute function...", async () =>
             {
                 await EnsureRoutineParametersLoadedAsync(node, viewModel);
                 viewModel.OpenQueryEditorWithScript(DatabaseObjectScriptBuilder.BuildSelectFunctionScript(viewModel.ConnectionSettings, node));
+            }));
+
+            sqlScriptItems.Add(new Separator());
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to new Query", async () =>
+            {
+                await OpenDatabaseDdlAsync(node, viewModel, openInEditor: true);
+            }));
+
+            sqlScriptItems.Add(CreateMenuItem("DDL Create to clipboard", async () =>
+            {
+                await OpenDatabaseDdlAsync(node, viewModel, openInEditor: false);
+            }));
+        }
+
+        while (sqlScriptItems.Count > 0 && sqlScriptItems[^1] is Separator)
+            sqlScriptItems.RemoveAt(sqlScriptItems.Count - 1);
+
+        if (sqlScriptItems.Count > 0)
+        {
+            if (items.Count > 0)
+                items.Add(new Separator());
+
+            items.Add(new MenuItem { Header = "SQL Scripts", ItemsSource = sqlScriptItems });
+        }
+
+        if (node.NodeType is NodeType.Table or NodeType.View or NodeType.Procedure or NodeType.Function)
+        {
+            if (items.Count > 0)
+                items.Add(new Separator());
+
+            items.Add(CreateMenuItem(GetDropMenuText(node), async () =>
+            {
+                await DropObjectAsync(node, viewModel);
             }));
         }
 
@@ -181,5 +266,99 @@ public partial class TabConnectionView : UserControl
             return;
 
         await viewModel.SchemaExplorer.LoadNodeAsync(parameterFolder);
+    }
+
+    private static async Task EnsureTableColumnsLoadedAsync(SchemaNode node, TabConnectionViewModel viewModel)
+    {
+        var columnFolder = node.Children.FirstOrDefault(child => child.NodeType == NodeType.Columns);
+        if (columnFolder is null || !columnFolder.CanLoad)
+            return;
+
+        await viewModel.SchemaExplorer.LoadNodeAsync(columnFolder);
+    }
+
+    private async Task OpenDatabaseDdlAsync(SchemaNode node, TabConnectionViewModel viewModel, bool openInEditor)
+    {
+        var ddlQuery = DatabaseObjectScriptBuilder.TryBuildNativeDdlRetrievalScript(viewModel.ConnectionSettings, node)
+                       ?? DatabaseObjectScriptBuilder.BuildObjectDdlRetrievalScript(viewModel.ConnectionSettings, node);
+        await using var connection = viewModel.ConnectionSettings.GetDatabaseProvider().GetConnection();
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = ddlQuery;
+
+        await using var reader = await command.ExecuteReaderAsync();
+        var ddl = await ReadDdlAsync(reader);
+        ddl = string.IsNullOrWhiteSpace(ddl) ? "-- DDL not found." : ddl;
+
+        if (openInEditor)
+            viewModel.OpenQueryEditorWithScript(ddl);
+        else
+            await CopyToClipboardAsync(ddl);
+    }
+
+    private async Task OpenTableDdlAsync(SchemaNode node, TabConnectionViewModel viewModel, bool openInEditor)
+    {
+        var nativeDdlQuery = DatabaseObjectScriptBuilder.TryBuildNativeDdlRetrievalScript(viewModel.ConnectionSettings, node);
+        if (!string.IsNullOrWhiteSpace(nativeDdlQuery))
+        {
+            await OpenDatabaseDdlAsync(node, viewModel, openInEditor);
+            return;
+        }
+
+        await EnsureTableColumnsLoadedAsync(node, viewModel);
+        var ddl = DatabaseObjectScriptBuilder.BuildDdlScript(viewModel.ConnectionSettings, node);
+
+        if (openInEditor)
+            viewModel.OpenQueryEditorWithScript(ddl);
+        else
+            await CopyToClipboardAsync(ddl);
+    }
+
+    private static string GetDropMenuText(SchemaNode node)
+    {
+        var objectType = node.NodeType switch
+        {
+            NodeType.Table => "table",
+            NodeType.View => "view",
+            NodeType.Procedure => "procedure",
+            NodeType.Function => "function",
+            _ => "object"
+        };
+
+        return $"Drop {objectType} {node.Name}";
+    }
+
+    private static async Task DropObjectAsync(SchemaNode node, TabConnectionViewModel viewModel)
+    {
+        if (!await viewModel.ConfirmDropAsync(node))
+            return;
+
+        var dropScript = DatabaseObjectScriptBuilder.BuildDropScript(viewModel.ConnectionSettings, node);
+        await viewModel.ExecuteBackgroundStatementAsync(dropScript, refreshSchema: true);
+    }
+
+    private static async Task<string> ReadDdlAsync(DbDataReader reader)
+    {
+        var parts = new List<string>();
+
+        do
+        {
+            while (await reader.ReadAsync())
+            {
+                var createColumnIndex = Enumerable.Range(0, reader.FieldCount)
+                    .FirstOrDefault(index => reader.GetName(index).StartsWith("Create ", StringComparison.OrdinalIgnoreCase), -1);
+
+                if (createColumnIndex >= 0 && createColumnIndex < reader.FieldCount && !await reader.IsDBNullAsync(createColumnIndex))
+                {
+                    parts.Add(reader.GetString(createColumnIndex));
+                    continue;
+                }
+
+                if (!await reader.IsDBNullAsync(0))
+                    parts.Add(reader.GetString(0));
+            }
+        } while (await reader.NextResultAsync());
+
+        return string.Join($"{Environment.NewLine}{Environment.NewLine}", parts.Where(part => !string.IsNullOrWhiteSpace(part)));
     }
 }


### PR DESCRIPTION
## Summary
- improve schema explorer context menu and background drop actions
- refresh schema tree more precisely after DDL without collapsing everything
- use provider-specific table DDL retrieval for MySQL, SQL Server, and PostgreSQL
- tighten completion/parameter handling regressions covered during this work

## Validation
- dotnet test DataDeveloper.Tests/DataDeveloper.Tests.csproj