### PR TITLE
feat: improve connection selector filtering UI

### DIFF
--- a/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
+++ b/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reactive.Threading.Tasks;
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Models;
+using DataDeveloper.Data.Providers.MySql;
 using DataDeveloper.Data.Providers.Oracle;
 using DataDeveloper.Data.Providers.SqLite;
 using DataDeveloper.Data.Providers.SqlServer;
@@ -148,10 +149,9 @@ public class ConnectionSelectorViewModelTests
             new FakeConnectionSettingsRepository(),
             new DatabaseProviderFactoryService(),
             new InMemorySecretStore(),
-            new FakeDialogService())
-        {
-            SelectedDatabaseType = DatabaseType.Oracle
-        };
+            new FakeDialogService());
+
+        viewModel.SelectedConnectionFilter = viewModel.AvailableConnectionFilters.Single(option => option.DatabaseType == DatabaseType.Oracle);
 
         await viewModel.AddCommand.Execute().ToTask();
 
@@ -167,10 +167,9 @@ public class ConnectionSelectorViewModelTests
             new FakeConnectionSettingsRepository(),
             new DatabaseProviderFactoryService(),
             new InMemorySecretStore(),
-            new FakeDialogService())
-        {
-            SelectedDatabaseType = DatabaseType.SqLite
-        };
+            new FakeDialogService());
+
+        viewModel.SelectedConnectionFilter = viewModel.AvailableConnectionFilters.Single(option => option.DatabaseType == DatabaseType.SqLite);
 
         await viewModel.AddCommand.Execute().ToTask();
 
@@ -235,5 +234,51 @@ public class ConnectionSelectorViewModelTests
         await viewModel.CreateSqLiteFileCommand.Execute().ToTask();
 
         Assert.Equal("/tmp/new-app.db", connection.Database);
+    }
+
+    [Fact]
+    public void Constructor_StartsWithAllFilterSelected_AndAddDisabled()
+    {
+        var viewModel = new ConnectionSelectorViewModel(
+            new FakeConnectionSettingsRepository(),
+            new DatabaseProviderFactoryService(),
+            new InMemorySecretStore(),
+            new FakeDialogService());
+
+        Assert.Equal("(All)", viewModel.SelectedConnectionFilter?.DisplayName);
+        Assert.False(viewModel.CanAddConnection);
+        Assert.True(viewModel.ShowFilterSelectionHint);
+    }
+
+    [Fact]
+    public void ChangingFilter_RestrictsVisibleConnections()
+    {
+        var sqlServerConnection = new SqlServerConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            Name = "Sql Server",
+            DatabaseType = DatabaseType.SqlServer
+        };
+        var mySqlConnection = new MySqlConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            Name = "MySql",
+            DatabaseType = DatabaseType.MySql
+        };
+
+        var viewModel = new ConnectionSelectorViewModel(
+            new FakeConnectionSettingsRepository([sqlServerConnection, mySqlConnection]),
+            new DatabaseProviderFactoryService(),
+            new InMemorySecretStore(),
+            new FakeDialogService());
+
+        Assert.Equal(2, viewModel.Connections.Count);
+
+        viewModel.SelectedConnectionFilter = viewModel.AvailableConnectionFilters.Single(option => option.DatabaseType == DatabaseType.MySql);
+
+        var filteredConnection = Assert.Single(viewModel.Connections);
+        Assert.Equal(DatabaseType.MySql, filteredConnection.DatabaseType);
+        Assert.True(viewModel.CanAddConnection);
+        Assert.False(viewModel.ShowFilterSelectionHint);
     }
 }

--- a/DataDeveloper/Controls/DatabaseTypeIcon.axaml
+++ b/DataDeveloper/Controls/DatabaseTypeIcon.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:svg="clr-namespace:Avalonia.Svg;assembly=Svg.Controls.Avalonia"
+             x:Class="DataDeveloper.Controls.DatabaseTypeIcon"
+             x:Name="Root">
+    <Border Width="{Binding BadgeSize, ElementName=Root}"
+            Height="{Binding BadgeSize, ElementName=Root}"
+            Background="White"
+            BorderBrush="#D8D8D8"
+            BorderThickness="1"
+            CornerRadius="999"
+            Padding="{Binding BadgePadding, ElementName=Root}">
+        <svg:Svg Width="{Binding IconSize, ElementName=Root}"
+                 Height="{Binding IconSize, ElementName=Root}"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center"
+                 Path="{Binding DatabaseType, ElementName=Root, Converter={StaticResource EnumValueToResource}}" />
+    </Border>
+</UserControl>

--- a/DataDeveloper/Controls/DatabaseTypeIcon.axaml.cs
+++ b/DataDeveloper/Controls/DatabaseTypeIcon.axaml.cs
@@ -1,0 +1,48 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace DataDeveloper.Controls;
+
+public partial class DatabaseTypeIcon : UserControl
+{
+    public static readonly StyledProperty<object?> DatabaseTypeProperty =
+        AvaloniaProperty.Register<DatabaseTypeIcon, object?>(nameof(DatabaseType));
+
+    public static readonly StyledProperty<double> BadgeSizeProperty =
+        AvaloniaProperty.Register<DatabaseTypeIcon, double>(nameof(BadgeSize), 28d);
+
+    public static readonly StyledProperty<double> IconSizeProperty =
+        AvaloniaProperty.Register<DatabaseTypeIcon, double>(nameof(IconSize), 18d);
+
+    public static readonly StyledProperty<Thickness> BadgePaddingProperty =
+        AvaloniaProperty.Register<DatabaseTypeIcon, Thickness>(nameof(BadgePadding), new Thickness(4));
+
+    public DatabaseTypeIcon()
+    {
+        InitializeComponent();
+    }
+
+    public object? DatabaseType
+    {
+        get => GetValue(DatabaseTypeProperty);
+        set => SetValue(DatabaseTypeProperty, value);
+    }
+
+    public double BadgeSize
+    {
+        get => GetValue(BadgeSizeProperty);
+        set => SetValue(BadgeSizeProperty, value);
+    }
+
+    public double IconSize
+    {
+        get => GetValue(IconSizeProperty);
+        set => SetValue(IconSizeProperty, value);
+    }
+
+    public Thickness BadgePadding
+    {
+        get => GetValue(BadgePaddingProperty);
+        set => SetValue(BadgePaddingProperty, value);
+    }
+}

--- a/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
+++ b/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
@@ -24,12 +24,26 @@ using DynamicData;
 
 namespace DataDeveloper.ViewModels;
 
+public sealed class ConnectionTypeFilterOption
+{
+    public ConnectionTypeFilterOption(string displayName, DatabaseType? databaseType)
+    {
+        DisplayName = displayName;
+        DatabaseType = databaseType;
+    }
+
+    public string DisplayName { get; }
+    public DatabaseType? DatabaseType { get; }
+    public bool HasDatabaseType => DatabaseType is not null;
+}
+
 public class ConnectionSelectorViewModel : ViewModelBase
 {
     private readonly IConnectionSettingsRepository _connectionSettingsRepository;
     private readonly DatabaseProviderFactoryService _databaseProviderFactoryService;
     private readonly ISecretStore _secretStore;
     private readonly IDialogService _dialogService;
+    private readonly ObservableCollection<ConnectionSettings> _allConnections = new();
 
     public ConnectionSelectorViewModel(IConnectionSettingsRepository connectionSettingsRepository, DatabaseProviderFactoryService databaseProviderFactoryService, ISecretStore secretStore, IDialogService dialogService)
     {
@@ -37,13 +51,26 @@ public class ConnectionSelectorViewModel : ViewModelBase
         _databaseProviderFactoryService = databaseProviderFactoryService;
         _secretStore = secretStore;
         _dialogService = dialogService;
+        AvailableConnectionFilters =
+        [
+            new ConnectionTypeFilterOption("(All)", null),
+            new ConnectionTypeFilterOption("SQL Server", DatabaseType.SqlServer),
+            new ConnectionTypeFilterOption("Oracle", DatabaseType.Oracle),
+            new ConnectionTypeFilterOption("PostgreSQL", DatabaseType.PostgresSql),
+            new ConnectionTypeFilterOption("MySQL", DatabaseType.MySql),
+            new ConnectionTypeFilterOption("SQLite", DatabaseType.SqLite)
+        ];
         LoadConnections();
-        SelectedDatabaseType = DatabaseType.SqlServer;
+        SelectedConnectionFilter = AvailableConnectionFilters[0];
         
         AddCommand = ReactiveCommand.Create(() =>
         {
-            var newConn = CreateConnectionSettings(SelectedDatabaseType);
-            Connections.Add(newConn);
+            if (SelectedConnectionFilter?.DatabaseType is not DatabaseType databaseType)
+                return;
+
+            var newConn = CreateConnectionSettings(databaseType);
+            _allConnections.Add(newConn);
+            RefreshFilteredConnections();
             SelectedConnection = newConn;
             IsEditing = true;
         });
@@ -106,7 +133,8 @@ public class ConnectionSelectorViewModel : ViewModelBase
         duplicate.Id = Guid.NewGuid();
         duplicate.CredentialId = null;
         duplicate.LoadedPasswordSnapshot = null;
-        Connections.Add(duplicate);
+        _allConnections.Add(duplicate);
+        RefreshFilteredConnections();
         SelectedConnection = duplicate;
         IsEditing = true;
     }
@@ -150,7 +178,8 @@ public class ConnectionSelectorViewModel : ViewModelBase
             if (connectionModel is not null)
             {
                 await Task.Run(() => _connectionSettingsRepository.Delete(connectionModel));
-                Connections.Remove(connectionModel);
+                _allConnections.Remove(connectionModel);
+                RefreshFilteredConnections();
             }
 
             SelectedConnection = Connections.FirstOrDefault();
@@ -159,8 +188,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
     }
 
     public ObservableCollection<ConnectionSettings> Connections { get; private set; } = new();
-    public IReadOnlyList<DatabaseType> AvailableDatabaseTypes { get; } =
-        [DatabaseType.SqlServer, DatabaseType.Oracle, DatabaseType.PostgresSql, DatabaseType.MySql, DatabaseType.SqLite];
+    public IReadOnlyList<ConnectionTypeFilterOption> AvailableConnectionFilters { get; }
 
     private ConnectionSettings? _selectedConnection;
     public ConnectionSettings? SelectedConnection
@@ -169,8 +197,6 @@ public class ConnectionSelectorViewModel : ViewModelBase
         set
         {
             this.RaiseAndSetIfChanged(ref _selectedConnection, value);
-            if (value is not null)
-                SelectedDatabaseType = value.DatabaseType;
             this.RaisePropertyChanged(nameof(IsMySqlConnectionSelected));
             this.RaisePropertyChanged(nameof(IsOracleConnectionSelected));
             this.RaisePropertyChanged(nameof(IsPostgresConnectionSelected));
@@ -184,11 +210,17 @@ public class ConnectionSelectorViewModel : ViewModelBase
         }
     }
 
-    private DatabaseType _selectedDatabaseType;
-    public DatabaseType SelectedDatabaseType
+    private ConnectionTypeFilterOption? _selectedConnectionFilter;
+    public ConnectionTypeFilterOption? SelectedConnectionFilter
     {
-        get => _selectedDatabaseType;
-        set => this.RaiseAndSetIfChanged(ref _selectedDatabaseType, value);
+        get => _selectedConnectionFilter;
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _selectedConnectionFilter, value);
+            RefreshFilteredConnections();
+            this.RaisePropertyChanged(nameof(CanAddConnection));
+            this.RaisePropertyChanged(nameof(ShowFilterSelectionHint));
+        }
     }
 
     private bool _isEditing;
@@ -216,6 +248,8 @@ public class ConnectionSelectorViewModel : ViewModelBase
     };
     public bool IsSecureStorageUnavailable => !_secretStore.IsAvailable;
     public string SecureStorageWarningMessage => _secretStore.UnavailableReason ?? string.Empty;
+    public bool CanAddConnection => SelectedConnectionFilter?.DatabaseType is not null;
+    public bool ShowFilterSelectionHint => !CanAddConnection;
     
     public SqlConnectionInfo? ConnectionInfo { get; private set; }
 
@@ -276,18 +310,46 @@ public class ConnectionSelectorViewModel : ViewModelBase
         
         IsEditing = false;
 
-        var sortedConnections = Connections.OrderBy(connection => connection.Name).ToList();
-        Connections.Clear();
-        Connections.AddRange(sortedConnections);
+        SortAllConnections();
+        RefreshFilteredConnections();
         SelectedConnection = connectionSettings;
     }
 
     private void LoadConnections()
     {
         var sortedList = _connectionSettingsRepository.LoadAll();
-        Connections.Clear();
+        _allConnections.Clear();
         if (sortedList is not null)
-            Connections.AddRange(sortedList.OrderBy(s => s.Name));
+            _allConnections.AddRange(sortedList.OrderBy(s => s.Name));
+        RefreshFilteredConnections();
+    }
+
+    private void SortAllConnections()
+    {
+        var sortedConnections = _allConnections.OrderBy(connection => connection.Name).ToList();
+        _allConnections.Clear();
+        _allConnections.AddRange(sortedConnections);
+    }
+
+    private void RefreshFilteredConnections()
+    {
+        var selectedConnectionId = SelectedConnection?.Id;
+        var filteredConnections = _allConnections
+            .Where(connection => SelectedConnectionFilter?.DatabaseType is null || connection.DatabaseType == SelectedConnectionFilter.DatabaseType)
+            .OrderBy(connection => connection.Name)
+            .ToList();
+
+        Connections.Clear();
+        Connections.AddRange(filteredConnections);
+
+        if (selectedConnectionId is null)
+        {
+            if (SelectedConnection is null || !Connections.Contains(SelectedConnection))
+                SelectedConnection = Connections.FirstOrDefault();
+            return;
+        }
+
+        SelectedConnection = Connections.FirstOrDefault(connection => connection.Id == selectedConnectionId) ?? Connections.FirstOrDefault();
     }
 
     private static ConnectionSettings CreateConnectionSettings(DatabaseType databaseType)

--- a/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
+++ b/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
@@ -3,7 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModels="clr-namespace:DataDeveloper.ViewModels"
-             xmlns:svg="clr-namespace:Avalonia.Svg;assembly=Svg.Controls.Avalonia"
+             xmlns:controls="clr-namespace:DataDeveloper.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="DataDeveloper.Views.ConnectionSelectorDialogView">
 <!-- Bind the corresponding ViewModel -->
@@ -21,52 +21,81 @@
         </StackPanel>
 
         <!-- Main body: left for list, right for connection details -->
-        <Grid ColumnDefinitions="2*,3*" RowDefinitions="*, Auto" >
+        <Grid ColumnDefinitions="2*,3*" RowDefinitions="*" >
 
-            <!-- List of configured connections -->
-            <ListBox Grid.Row="0" Grid.Column="0" ItemsSource="{Binding Connections}"
-                SelectedItem="{Binding SelectedConnection, Mode=TwoWay}"
-                Margin="0,0,10,0"
-                >
-                <ListBox.ItemTemplate>
-                    <DataTemplate>
-                        <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*,Auto,Auto">
-                            <svg:Svg Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Width="24" Height="24" Path="{Binding DatabaseType, Converter={StaticResource EnumValueToResource}}" />
-                            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Name}" VerticalAlignment="Center"  />
-                            <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding DatabaseType}" VerticalAlignment="Center"  FontSize="10" />
-                            <Button Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" 
-                                    Background="Transparent" ToolTip.Tip="Edit"
-                                    Command="{Binding DataContext.EditCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                    CommandParameter="{Binding .}"
-                                    >
-                                <TextBlock Text="&#xf304;" FontFamily="{StaticResource FontAwesomeSolid}" />
-                            </Button>
-                            <Button Grid.Row="0" Grid.Column="3" Grid.RowSpan="2" 
-                                    Background="Transparent" ToolTip.Tip="Delete"
-                                    Command="{Binding DataContext.DeleteCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
-                                    CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
-                                    >
-                                <TextBlock Text="&#xf2ed;" FontFamily="{StaticResource FontAwesomeSolid}" Foreground="Brown" />
-                            </Button>
-                        </Grid>
-                    </DataTemplate>
-                </ListBox.ItemTemplate>
-            </ListBox>
+            <Grid Grid.Column="0" Margin="0,0,10,0" RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="8">
+                <TextBlock Grid.Row="0"
+                           Text="Connection Types" />
 
-            <StackPanel Grid.Row="1" Grid.Column="0"
-                        Orientation="Horizontal"
-                        HorizontalAlignment="Right"
-                        Spacing="8"
-                        Margin="0,10,10,0">
-                <ComboBox Width="140"
-                          ItemsSource="{Binding AvailableDatabaseTypes}"
-                          SelectedItem="{Binding SelectedDatabaseType, Mode=TwoWay}" />
-                <Button Content="Add new connection"
-                        Command="{Binding AddCommand}" />
-            </StackPanel>
+                <ComboBox Grid.Row="1"
+                          HorizontalAlignment="Stretch"
+                          ItemsSource="{Binding AvailableConnectionFilters}"
+                          SelectedItem="{Binding SelectedConnectionFilter, Mode=TwoWay}"
+                          >
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                                <controls:DatabaseTypeIcon Grid.Column="0"
+                                                           DatabaseType="{Binding DatabaseType}"
+                                                           BadgeSize="24"
+                                                           IconSize="14"
+                                                           BadgePadding="3"
+                                                           IsVisible="{Binding HasDatabaseType}" />
+                                <TextBlock Grid.Column="1"
+                                           Text="{Binding DisplayName}"
+                                           VerticalAlignment="Center" />
+                            </Grid>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+
+                <TextBlock Grid.Row="2"
+                           Text="Select a type to filter or to add a new connection."
+                           FontSize="11"
+                           Foreground="DarkGoldenrod"
+                           TextWrapping="Wrap" />
+
+                <ListBox Grid.Row="3"
+                         ItemsSource="{Binding Connections}"
+                         SelectedItem="{Binding SelectedConnection, Mode=TwoWay}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*,Auto,Auto">
+                                <controls:DatabaseTypeIcon Grid.Row="0"
+                                                           Grid.Column="0"
+                                                           Grid.RowSpan="2"
+                                                           DatabaseType="{Binding DatabaseType}"
+                                                           VerticalAlignment="Top" Margin="0, 0, 5, 0" />
+                                <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Name}" VerticalAlignment="Center"  />
+                                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding DatabaseType}" VerticalAlignment="Center"  FontSize="10" />
+                                <Button Grid.Row="0" Grid.Column="2" Grid.RowSpan="2" 
+                                        Background="Transparent" ToolTip.Tip="Edit"
+                                        Command="{Binding DataContext.EditCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding .}"
+                                        >
+                                    <TextBlock Text="&#xf304;" FontFamily="{StaticResource FontAwesomeSolid}" />
+                                </Button>
+                                <Button Grid.Row="0" Grid.Column="3" Grid.RowSpan="2" 
+                                        Background="Transparent" ToolTip.Tip="Delete"
+                                        Command="{Binding DataContext.DeleteCommand, RelativeSource={RelativeSource AncestorType=ListBox}}"
+                                        CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
+                                        >
+                                    <TextBlock Text="&#xf2ed;" FontFamily="{StaticResource FontAwesomeSolid}" Foreground="Brown" />
+                                </Button>
+                            </Grid>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <Button Grid.Row="4"
+                        Content="Add new connection"
+                        Command="{Binding AddCommand}"
+                        IsEnabled="{Binding CanAddConnection}"
+                        HorizontalAlignment="Right" />
+            </Grid>
 
             <!-- Connection detail view -->
-            <StackPanel Grid.Row="0" Grid.Column="1" Grid.RowSpan="2" Spacing="8">
+            <StackPanel Grid.Column="1" Spacing="8">
 
                 <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="3*,1*" ColumnSpacing="10" RowSpacing="8">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Name" />

--- a/DataDeveloper/Views/MainView.axaml
+++ b/DataDeveloper/Views/MainView.axaml
@@ -4,7 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:DataDeveloper.ViewModels"
              xmlns:templateSelectors="clr-namespace:DataDeveloper.TemplateSelectors"
-             xmlns:svg="clr-namespace:Avalonia.Svg;assembly=Svg.Controls.Avalonia"
+             xmlns:controls="clr-namespace:DataDeveloper.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="DataDeveloper.Views.MainView">
     <Design.DataContext>
@@ -36,7 +36,7 @@
                 <TabControl.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal" Spacing="5" Margin="10,0,10,0">
-                            <svg:Svg Width="24" Height="24" Path="{Binding ConnectionSettings.DatabaseType, Converter={StaticResource EnumValueToResource}}" />
+                            <controls:DatabaseTypeIcon DatabaseType="{Binding ConnectionSettings.DatabaseType}" />
                             <TextBlock FontSize="13" Text="{Binding Name}" VerticalAlignment="Center" />
                             <Button 
                                 Background="Transparent" 


### PR DESCRIPTION
## Summary
- turn the connection type picker into a real filter with an all state
- add reusable database type icon badges for dark theme contrast
- improve connection selector layout and keep filter guidance visible

## Validation
- dotnet test DataDeveloper.Tests/DataDeveloper.Tests.csproj