### PR TITLE
Add editor menu, About dialog, and token-based beautify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,13 @@
 - Provider documentation updates must cover supported providers and any local setup needed to validate the new provider during development.
 - Keep `README.md` user-focused. Do not add internal workflows, local-only test instructions, release mechanics, or other team-facing technical details there unless the user explicitly asks for that content in `README.md`.
 - Put team-facing technical documentation such as local validation steps, integration test setup, and internal workflows in dedicated files like `TESTS.md` unless the user explicitly asks for a different location.
+
+## Platform guidelines
+- UI behavior must follow the conventions of the operating system currently running the app.
+- Keyboard shortcuts, menu gesture labels, context menu behavior, window actions, and similar UX details must use the platform-appropriate conventions instead of hardcoded Windows behavior.
+- On macOS, prefer `Command`-based shortcuts and macOS menu expectations; on Windows/Linux, prefer the native conventions for those platforms.
+
+## UI styles
+- Reuse shared Avalonia styles for repeated UI patterns instead of duplicating visual properties inline on each control.
+- Dialog and action buttons should prefer the shared dialog button styles (for example `dialog-button` and `dialog-button.primary`) unless there is a clear reason to diverge.
+- When a visual pattern starts being reused across windows, dialogs, or menus, promote it to a shared style in `App.axaml` or another dedicated theme/style file.

--- a/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
+++ b/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
@@ -73,6 +73,8 @@ public class ConnectionSelectorViewModelTests
 
         public Task ShowMessageAsync(string message, string? title = null) => Task.CompletedTask;
 
+        public Task ShowAboutAsync(string version, Func<Task> checkForUpdatesAsync) => Task.CompletedTask;
+
         public Task<DialogResult> ShowReleaseUpdateAsync(string message, string? title = null) => Task.FromResult(DialogResult.Cancel);
 
         public Task<string?> ShowSaveFileDialogAsync(string? suggestedName = null, string? title = null) => Task.FromResult<string?>(null);

--- a/DataDeveloper.Tests/ReleaseUpdateServiceTests.cs
+++ b/DataDeveloper.Tests/ReleaseUpdateServiceTests.cs
@@ -125,6 +125,43 @@ public sealed class ReleaseUpdateServiceTests
     }
 
     [Fact]
+    public async Task CheckForUpdatesAsync_ShowsUpToDateMessage_WhenNoNewReleaseExists()
+    {
+        var stateFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json");
+        try
+        {
+            using var httpClient = new HttpClient(new StubHttpMessageHandler("""
+            {
+              "tag_name": "v1.2.0",
+              "name": "Version 1.2.0",
+              "html_url": "https://github.com/NelsonSantos/DataDeveloper/releases/tag/v1.2.0",
+              "body": "Current release.",
+              "draft": false,
+              "prerelease": false
+            }
+            """));
+            var dialogService = new RecordingDialogService();
+            var service = new ReleaseUpdateService(
+                dialogService,
+                httpClient,
+                stateFilePath,
+                "1.2.0",
+                () => new DateTimeOffset(2026, 4, 2, 12, 0, 0, TimeSpan.Zero));
+
+            await service.CheckForUpdatesAsync();
+
+            Assert.Single(dialogService.Messages);
+            Assert.Contains("Data Developer is up to date.", dialogService.Messages[0]);
+            Assert.Empty(dialogService.ReleaseUpdateMessages);
+        }
+        finally
+        {
+            if (File.Exists(stateFilePath))
+                File.Delete(stateFilePath);
+        }
+    }
+
+    [Fact]
     public void ExtractSummary_ReturnsSummarySectionWithoutReleaseDraftHeader()
     {
         const string releaseBody = """
@@ -173,6 +210,8 @@ public sealed class ReleaseUpdateServiceTests
             Messages.Add(message);
             return Task.CompletedTask;
         }
+
+        public Task ShowAboutAsync(string version, Func<Task> checkForUpdatesAsync) => Task.CompletedTask;
 
         public Task<DialogResult> ShowReleaseUpdateAsync(string message, string? title = null)
         {

--- a/DataDeveloper.Tests/SqlEditorTextOperationsTests.cs
+++ b/DataDeveloper.Tests/SqlEditorTextOperationsTests.cs
@@ -1,0 +1,93 @@
+using DataDeveloper.Services;
+using DataDeveloper.Data.Enums;
+using Xunit;
+
+namespace DataDeveloper.Tests;
+
+public sealed class SqlEditorTextOperationsTests
+{
+    [Fact]
+    public void ToUpper_WithoutSelection_ReturnsNull()
+    {
+        var result = SqlEditorTextOperations.ToUpper("select 1", 0, 0);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ToLower_WithSelection_TransformsOnlySelection()
+    {
+        var result = SqlEditorTextOperations.ToLower("SELECT Name FROM dbo.Users", 0, 6);
+
+        Assert.True(result.HasValue);
+        Assert.Equal("select", result.Value.ReplacementText);
+        Assert.Equal(0, result.Value.SelectionStart);
+        Assert.Equal(6, result.Value.SelectionLength);
+    }
+
+    [Fact]
+    public void Indent_WithSelection_IndentsAllTouchedLines()
+    {
+        var sql = "select a,\nfrom users";
+
+        var result = SqlEditorTextOperations.Indent(sql, 0, sql.Length, "    ");
+
+        Assert.Equal("    select a,\n    from users", result.ReplacementText);
+        Assert.Equal(0, result.SelectionStart);
+        Assert.Equal(result.ReplacementText.Length, result.SelectionLength);
+    }
+
+    [Fact]
+    public void Unindent_WithoutSelection_RemovesOneIndentLevelFromCurrentLine()
+    {
+        var sql = "    select 1";
+
+        var result = SqlEditorTextOperations.Unindent(sql, 4, 0, "    ");
+
+        Assert.Equal("select 1", result.ReplacementText);
+        Assert.Equal(0, result.SelectionStart);
+        Assert.Equal(0, result.SelectionLength);
+    }
+
+    [Fact]
+    public void Comment_CommentsAllTouchedLines()
+    {
+        var sql = "select 1\n  from dual";
+
+        var result = SqlEditorTextOperations.Comment(sql, 0, sql.Length);
+
+        Assert.Equal("-- select 1\n  -- from dual", result.ReplacementText);
+    }
+
+    [Fact]
+    public void Uncomment_RemovesSqlLineCommentPrefix()
+    {
+        var sql = "-- select 1\n  -- from dual";
+
+        var result = SqlEditorTextOperations.Uncomment(sql, 0, sql.Length);
+
+        Assert.Equal("select 1\n  from dual", result.ReplacementText);
+    }
+
+    [Fact]
+    public void Beautify_WithoutSelection_FormatsWholeDocument()
+    {
+        var sql = "select a, b from dbo.table where id = 1 and name = 'x'";
+
+        var result = SqlEditorTextOperations.Beautify(sql, 7, 0, "    ", DatabaseType.SqlServer);
+
+        Assert.Equal("select\n    a,\n    b\nfrom dbo.table\nwhere id = 1\n    and name = 'x'", result.ReplacementText);
+        Assert.Equal(7, result.SelectionStart);
+        Assert.Equal(0, result.SelectionLength);
+    }
+
+    [Fact]
+    public void Beautify_UsesMySqlLexerForMySqlStatements()
+    {
+        var sql = "select id,name from users where status='A' and role='admin'";
+
+        var result = SqlEditorTextOperations.Beautify(sql, 0, 0, "    ", DatabaseType.MySql);
+
+        Assert.Equal("select\n    id,\n    name\nfrom users\nwhere status = 'A'\n    and role = 'admin'", result.ReplacementText);
+    }
+}

--- a/DataDeveloper/App.axaml
+++ b/DataDeveloper/App.axaml
@@ -113,5 +113,22 @@
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
 
+        <Style Selector="Button.dialog-button">
+            <Setter Property="MinWidth" Value="96" />
+            <Setter Property="Padding" Value="18,10" />
+            <Setter Property="CornerRadius" Value="10" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="BorderBrush" Value="#FF4A505C" />
+            <Setter Property="Background" Value="#FF343A44" />
+        </Style>
+
+        <Style Selector="Button.dialog-button.primary">
+            <Setter Property="BorderBrush" Value="#FF5F7FE3" />
+            <Setter Property="Background" Value="#FF4D6DD1" />
+        </Style>
+
     </Application.Styles>
 </Application>

--- a/DataDeveloper/App.axaml.cs
+++ b/DataDeveloper/App.axaml.cs
@@ -89,7 +89,8 @@ public partial class App : Application
         var version = ApplicationVersionHelper.GetCurrentVersion(typeof(App).Assembly);
 
         var dialogService = ServiceProvider.GetRequiredService<IDialogService>();
-        await dialogService.ShowMessageAsync($"Data Developer\nVersion {version}", "About Data Developer");
+        var releaseUpdateService = ServiceProvider.GetRequiredService<IReleaseUpdateService>();
+        await dialogService.ShowAboutAsync(version, () => releaseUpdateService.CheckForUpdatesAsync());
     }
 
     private async void OnMainWindowOpened(object? sender, EventArgs e)

--- a/DataDeveloper/DataDeveloper.csproj
+++ b/DataDeveloper/DataDeveloper.csproj
@@ -50,4 +50,11 @@
     <ProjectReference Include="..\DataDeveloper.NextGrid\DataDeveloper.NextGrid.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\DataDeveloper.Data\StatementParser\MySql\MySQLLexer.cs" Link="Generated\MySql\MySQLLexer.cs" />
+    <Compile Include="..\DataDeveloper.Data\StatementParser\MySql\MySQLLexerBase.cs" Link="Generated\MySql\MySQLLexerBase.cs" />
+    <Compile Include="..\DataDeveloper.Data\StatementParser\MySql\SqlMode.cs" Link="Generated\MySql\SqlMode.cs" />
+    <Compile Include="..\DataDeveloper.Data\StatementParser\MySql\SqlModes.cs" Link="Generated\MySql\SqlModes.cs" />
+  </ItemGroup>
+
 </Project>

--- a/DataDeveloper/Helpers/TextEditorBindingHelper.cs
+++ b/DataDeveloper/Helpers/TextEditorBindingHelper.cs
@@ -102,7 +102,10 @@ public static class TextEditorBindingHelper
         BindableTextProperty.Changed.Subscribe(args =>
         {
             if (args.Sender is TextEditor editor)
+            {
                 AttachEvents(editor);
+                ApplyBindableText(editor, args.NewValue.GetValueOrDefault<string>() ?? string.Empty);
+            }
         });
 
         BindableSelectedTextProperty.Changed.Subscribe(args =>
@@ -151,25 +154,18 @@ public static class TextEditorBindingHelper
 
     private static string OnBindableTextChanged(AvaloniaObject obj, string newValue)
     {
-        if (obj is not TextEditor editor)
-            return newValue;
-
-        if (editor.Text != newValue)
-        {
-            editor.TextChanged -= OnDirectTextChanged;
-            editor.Text = newValue ?? string.Empty;
-            editor.TextChanged += OnDirectTextChanged;
-        }
-
         return newValue ?? string.Empty;
     }
 
-    private static void OnDirectTextChanged(object? sender, EventArgs e)
+    private static void ApplyBindableText(TextEditor editor, string newValue)
     {
-        if (sender is TextEditor editor)
+        Dispatcher.UIThread.Post(() =>
         {
-            SetBindableText(editor, editor.Text);
-        }
+            if (editor.Text == newValue)
+                return;
+
+            editor.Text = newValue;
+        }, DispatcherPriority.Background);
     }
 
     private static void DebouncedTextUpdate(TextEditor editor)

--- a/DataDeveloper/Interfaces/IDialogService.cs
+++ b/DataDeveloper/Interfaces/IDialogService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using DataDeveloper.Enums;
 using DataDeveloper.Views;
@@ -9,6 +10,7 @@ public interface IDialogService
     Task<DialogResult> ShowDialogAsync(string message, string? title = null, DialogButtons buttons = DialogButtons.Ok, DialogIcon icon = DialogIcon.Info);
     Task<DialogResult> ShowDialogResult(string message, string? title = null);
     Task ShowMessageAsync(string message, string? title = null);
+    Task ShowAboutAsync(string version, Func<Task> checkForUpdatesAsync);
     Task<DialogResult> ShowReleaseUpdateAsync(string message, string? title = null);
     Task<string?> ShowSaveFileDialogAsync(string? suggestedName = null, string? title = null);
     Task<string?> ShowOpenFileAsync(string? title = null);

--- a/DataDeveloper/Interfaces/IReleaseUpdateService.cs
+++ b/DataDeveloper/Interfaces/IReleaseUpdateService.cs
@@ -6,4 +6,5 @@ namespace DataDeveloper.Interfaces;
 public interface IReleaseUpdateService
 {
     Task NotifyIfUpdateAvailableAsync(CancellationToken cancellationToken = default);
+    Task CheckForUpdatesAsync(CancellationToken cancellationToken = default);
 }

--- a/DataDeveloper/Services/DialogService.cs
+++ b/DataDeveloper/Services/DialogService.cs
@@ -46,6 +46,13 @@ public class DialogService : IDialogService
         _ = await ShowDialogAsync(message, title, DialogButtons.Ok, DialogIcon.Info);
     }
 
+    public async Task ShowAboutAsync(string version, Func<Task> checkForUpdatesAsync)
+    {
+        var owner = GetOwnerWindow();
+        var dialog = new AboutWindow(version, checkForUpdatesAsync);
+        await dialog.ShowDialog(owner);
+    }
+
     public async Task<DialogResult> ShowReleaseUpdateAsync(string message, string? title = null)
     {
         var owner = GetOwnerWindow();

--- a/DataDeveloper/Services/ReleaseUpdateService.cs
+++ b/DataDeveloper/Services/ReleaseUpdateService.cs
@@ -75,6 +75,31 @@ public sealed partial class ReleaseUpdateService : IReleaseUpdateService
         }
     }
 
+    public async Task CheckForUpdatesAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var notification = await GetAvailableUpdateAsync(cancellationToken);
+            if (notification is null)
+            {
+                await _dialogService.ShowMessageAsync(
+                    $"Data Developer is up to date.\n\nCurrent version: {_currentVersion}",
+                    "Check for Updates");
+                return;
+            }
+
+            var result = await _dialogService.ShowReleaseUpdateAsync(BuildMessage(notification), "New Version Available");
+            if (result == DialogResult.Download && !string.IsNullOrWhiteSpace(notification.ReleaseUrl))
+                await BrowserLauncher.OpenAsync(notification.ReleaseUrl);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or JsonException or IOException)
+        {
+            await _dialogService.ShowMessageAsync(
+                "Unable to check for updates right now.\n\nPlease try again in a moment.",
+                "Check for Updates");
+        }
+    }
+
     public async Task<ReleaseUpdateNotification?> GetAvailableUpdateAsync(CancellationToken cancellationToken = default)
     {
         var state = LoadState();

--- a/DataDeveloper/Services/ServicesExtensionMethods.cs
+++ b/DataDeveloper/Services/ServicesExtensionMethods.cs
@@ -1,18 +1,32 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.VisualTree;
 
 namespace DataDeveloper.Services;
 
 public static class ServicesExtensionMethods
 {
+    public static Window? TryGetParentWindow(this StyledElement element)
+    {
+        if (element is Visual visual && TopLevel.GetTopLevel(visual) is Window topLevelWindow)
+            return topLevelWindow;
+
+        StyledElement? target = element;
+        while (target is not null)
+        {
+            if (target is Window window)
+                return window;
+
+            target = target.Parent;
+        }
+
+        return null;
+    }
+
     public static Window GetParentWindow(this StyledElement element)
     {
-        var target = element.Parent;
-        
-        if (target == null) throw new Exception("Could not get the parent window");
-        if (target is Window window) return window;
-        
-        return GetParentWindow(target);
+        return element.TryGetParentWindow()
+               ?? throw new Exception("Could not get the parent window");
     }
 }

--- a/DataDeveloper/Services/SqlEditorTextOperations.cs
+++ b/DataDeveloper/Services/SqlEditorTextOperations.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using DataDeveloper.Data.Enums;
+
+namespace DataDeveloper.Services;
+
+public static class SqlEditorTextOperations
+{
+    public static TextEditResult? ToUpper(string text, int selectionStart, int selectionLength)
+    {
+        return TransformSelection(text, selectionStart, selectionLength, value => value.ToUpperInvariant());
+    }
+
+    public static TextEditResult? ToLower(string text, int selectionStart, int selectionLength)
+    {
+        return TransformSelection(text, selectionStart, selectionLength, value => value.ToLowerInvariant());
+    }
+
+    public static TextEditResult Indent(string text, int selectionStart, int selectionLength, string indentation)
+    {
+        var lineRange = GetLineRange(text, selectionStart, selectionLength);
+        var segment = text.Substring(lineRange.Start, lineRange.Length);
+        var lines = SplitLines(segment);
+        var builder = new StringBuilder(segment.Length + lines.Count * indentation.Length);
+
+        foreach (var line in lines)
+        {
+            if (line.Content.Length == 0 && line.LineEnding.Length == 0)
+                continue;
+
+            builder.Append(indentation);
+            builder.Append(line.Content);
+            builder.Append(line.LineEnding);
+        }
+
+        if (selectionLength == 0)
+        {
+            return new TextEditResult(
+                lineRange.Start,
+                lineRange.Length,
+                builder.ToString(),
+                selectionStart + indentation.Length,
+                0);
+        }
+
+        return new TextEditResult(
+            lineRange.Start,
+            lineRange.Length,
+            builder.ToString(),
+            lineRange.Start,
+            builder.Length);
+    }
+
+    public static TextEditResult Unindent(string text, int selectionStart, int selectionLength, string indentation)
+    {
+        var lineRange = GetLineRange(text, selectionStart, selectionLength);
+        var segment = text.Substring(lineRange.Start, lineRange.Length);
+        var lines = SplitLines(segment);
+        var builder = new StringBuilder(segment.Length);
+        var currentLineRemoved = 0;
+        var currentLineIndex = GetCurrentLineIndex(lines, selectionStart - lineRange.Start);
+
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            var removed = GetUnindentLength(line.Content, indentation);
+            if (i == currentLineIndex)
+                currentLineRemoved = removed;
+
+            builder.Append(line.Content.AsSpan(removed));
+            builder.Append(line.LineEnding);
+        }
+
+        if (selectionLength == 0)
+        {
+            return new TextEditResult(
+                lineRange.Start,
+                lineRange.Length,
+                builder.ToString(),
+                Math.Max(lineRange.Start, selectionStart - currentLineRemoved),
+                0);
+        }
+
+        return new TextEditResult(
+            lineRange.Start,
+            lineRange.Length,
+            builder.ToString(),
+            lineRange.Start,
+            builder.Length);
+    }
+
+    public static TextEditResult Comment(string text, int selectionStart, int selectionLength)
+    {
+        var lineRange = GetLineRange(text, selectionStart, selectionLength);
+        var segment = text.Substring(lineRange.Start, lineRange.Length);
+        var lines = SplitLines(segment);
+        var builder = new StringBuilder(segment.Length + lines.Count * 3);
+        var currentLineDelta = 0;
+        var currentLineIndex = GetCurrentLineIndex(lines, selectionStart - lineRange.Start);
+
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            var indentLength = GetLeadingWhitespaceLength(line.Content);
+            builder.Append(line.Content.AsSpan(0, indentLength));
+            builder.Append("-- ");
+            builder.Append(line.Content.AsSpan(indentLength));
+            builder.Append(line.LineEnding);
+
+            if (i == currentLineIndex)
+                currentLineDelta = 3;
+        }
+
+        if (selectionLength == 0)
+        {
+            return new TextEditResult(
+                lineRange.Start,
+                lineRange.Length,
+                builder.ToString(),
+                selectionStart + currentLineDelta,
+                0);
+        }
+
+        return new TextEditResult(
+            lineRange.Start,
+            lineRange.Length,
+            builder.ToString(),
+            lineRange.Start,
+            builder.Length);
+    }
+
+    public static TextEditResult Uncomment(string text, int selectionStart, int selectionLength)
+    {
+        var lineRange = GetLineRange(text, selectionStart, selectionLength);
+        var segment = text.Substring(lineRange.Start, lineRange.Length);
+        var lines = SplitLines(segment);
+        var builder = new StringBuilder(segment.Length);
+        var currentLineRemoved = 0;
+        var currentLineIndex = GetCurrentLineIndex(lines, selectionStart - lineRange.Start);
+
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            var removed = GetCommentPrefixLength(line.Content);
+            if (i == currentLineIndex)
+                currentLineRemoved = removed;
+
+            if (removed > 0)
+            {
+                var indentLength = GetLeadingWhitespaceLength(line.Content);
+                builder.Append(line.Content.AsSpan(0, indentLength));
+                builder.Append(line.Content.AsSpan(indentLength + removed));
+            }
+            else
+            {
+                builder.Append(line.Content);
+            }
+
+            builder.Append(line.LineEnding);
+        }
+
+        if (selectionLength == 0)
+        {
+            return new TextEditResult(
+                lineRange.Start,
+                lineRange.Length,
+                builder.ToString(),
+                Math.Max(lineRange.Start, selectionStart - currentLineRemoved),
+                0);
+        }
+
+        return new TextEditResult(
+            lineRange.Start,
+            lineRange.Length,
+            builder.ToString(),
+            lineRange.Start,
+            builder.Length);
+    }
+
+    public static TextEditResult Beautify(string text, int selectionStart, int selectionLength, string indentation, DatabaseType databaseType)
+    {
+        var rangeStart = selectionLength > 0 ? selectionStart : 0;
+        var rangeLength = selectionLength > 0 ? selectionLength : text.Length;
+        var formatted = SqlTokenFormatter.Format(text.Substring(rangeStart, rangeLength), databaseType, indentation);
+        var selectionStartAfter = selectionLength > 0 ? rangeStart : Math.Min(selectionStart, formatted.Length);
+        var selectionLengthAfter = selectionLength > 0 ? formatted.Length : 0;
+
+        return new TextEditResult(rangeStart, rangeLength, formatted, selectionStartAfter, selectionLengthAfter);
+    }
+
+    private static TextEditResult? TransformSelection(string text, int selectionStart, int selectionLength, Func<string, string> transform)
+    {
+        if (selectionLength <= 0)
+            return null;
+
+        var replacement = transform(text.Substring(selectionStart, selectionLength));
+        return new TextEditResult(selectionStart, selectionLength, replacement, selectionStart, replacement.Length);
+    }
+
+    private static LineRange GetLineRange(string text, int selectionStart, int selectionLength)
+    {
+        var start = FindLineStart(text, selectionStart);
+        var end = selectionLength == 0
+            ? FindLineEnd(text, selectionStart)
+            : FindLineEnd(text, selectionStart + selectionLength);
+
+        return new LineRange(start, end - start);
+    }
+
+    private static int FindLineStart(string text, int offset)
+    {
+        var index = Math.Clamp(offset, 0, text.Length);
+        while (index > 0 && text[index - 1] is not '\n' and not '\r')
+            index--;
+
+        return index;
+    }
+
+    private static int FindLineEnd(string text, int offset)
+    {
+        var index = Math.Clamp(offset, 0, text.Length);
+        while (index < text.Length && text[index] is not '\n' and not '\r')
+            index++;
+
+        if (index < text.Length)
+        {
+            if (text[index] == '\r' && index + 1 < text.Length && text[index + 1] == '\n')
+                return index + 2;
+
+            return index + 1;
+        }
+
+        return index;
+    }
+
+    private static List<LineSegment> SplitLines(string value)
+    {
+        var lines = new List<LineSegment>();
+        var index = 0;
+
+        while (index < value.Length)
+        {
+            var lineStart = index;
+            while (index < value.Length && value[index] is not '\n' and not '\r')
+                index++;
+
+            var content = value.Substring(lineStart, index - lineStart);
+            var lineEnding = string.Empty;
+
+            if (index < value.Length)
+            {
+                if (value[index] == '\r' && index + 1 < value.Length && value[index + 1] == '\n')
+                {
+                    lineEnding = "\r\n";
+                    index += 2;
+                }
+                else
+                {
+                    lineEnding = value[index].ToString();
+                    index++;
+                }
+            }
+
+            lines.Add(new LineSegment(content, lineEnding));
+        }
+
+        if (value.Length == 0)
+            lines.Add(new LineSegment(string.Empty, string.Empty));
+
+        return lines;
+    }
+
+    private static int GetLeadingWhitespaceLength(string value)
+    {
+        var index = 0;
+        while (index < value.Length && char.IsWhiteSpace(value[index]))
+            index++;
+
+        return index;
+    }
+
+    private static int GetUnindentLength(string line, string indentation)
+    {
+        if (line.StartsWith(indentation, StringComparison.Ordinal))
+            return indentation.Length;
+
+        var spaces = 0;
+        while (spaces < line.Length && spaces < indentation.Length && line[spaces] == ' ')
+            spaces++;
+
+        return spaces;
+    }
+
+    private static int GetCommentPrefixLength(string line)
+    {
+        var indentLength = GetLeadingWhitespaceLength(line);
+        if (line.Length <= indentLength + 1 || line[indentLength] != '-' || line[indentLength + 1] != '-')
+            return 0;
+
+        return line.Length > indentLength + 2 && line[indentLength + 2] == ' ' ? 3 : 2;
+    }
+
+    private static int GetCurrentLineIndex(IReadOnlyList<LineSegment> lines, int relativeOffset)
+    {
+        var offset = 0;
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var lineLength = lines[i].Content.Length + lines[i].LineEnding.Length;
+            if (relativeOffset <= offset + lineLength)
+                return i;
+
+            offset += lineLength;
+        }
+
+        return Math.Max(0, lines.Count - 1);
+    }
+
+    private readonly record struct LineRange(int Start, int Length);
+    private readonly record struct LineSegment(string Content, string LineEnding);
+}
+
+public readonly record struct TextEditResult(
+    int ReplaceStart,
+    int ReplaceLength,
+    string ReplacementText,
+    int SelectionStart,
+    int SelectionLength);

--- a/DataDeveloper/Services/SqlTokenFormatter.cs
+++ b/DataDeveloper/Services/SqlTokenFormatter.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Antlr4.Runtime;
+using DataDeveloper.Data.Enums;
+using SqlServer;
+
+namespace DataDeveloper.Services;
+
+public static class SqlTokenFormatter
+{
+    private static readonly HashSet<string> MajorClauses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SELECT", "FROM", "WHERE", "GROUP BY", "ORDER BY", "HAVING",
+        "INSERT INTO", "UPDATE", "DELETE FROM", "VALUES", "SET",
+        "JOIN", "INNER JOIN", "LEFT JOIN", "RIGHT JOIN", "FULL JOIN",
+        "CROSS JOIN", "LEFT OUTER JOIN", "RIGHT OUTER JOIN", "FULL OUTER JOIN",
+        "ON", "UNION", "UNION ALL", "LIMIT", "OFFSET"
+    };
+
+    private static readonly HashSet<string> ListClauses = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "SELECT", "SET", "VALUES"
+    };
+
+    private static readonly HashSet<string> BreakLogicalOperators = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "AND", "OR"
+    };
+
+    private static readonly HashSet<string> Operators = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "=", "<", ">", "<=", ">=", "<>", "!=", "+", "-", "*", "/", "%", "||", ":="
+    };
+
+    public static string Format(string sql, DatabaseType databaseType, string indentation)
+    {
+        var tokens = TryTokenize(sql, databaseType);
+        if (tokens.Count == 0)
+            return sql.Trim();
+
+        var builder = new StringBuilder(sql.Length + 64);
+        var lineStart = true;
+        var pendingSpace = false;
+        var indentLevel = 0;
+        var currentClause = string.Empty;
+        var listClauseIndent = -1;
+
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var token = tokens[i];
+            if (token.Kind == SqlFormatTokenKind.Comment)
+            {
+                EnsureLineStart(builder, ref lineStart, ref pendingSpace);
+                WriteIndent(builder, indentLevel, indentation);
+                builder.Append(token.Text.Trim());
+                AppendNewLine(builder, ref lineStart, ref pendingSpace);
+                continue;
+            }
+
+            if (TryReadClause(tokens, i, out var clauseText, out var consumed))
+            {
+                if (builder.Length > 0)
+                    AppendNewLine(builder, ref lineStart, ref pendingSpace);
+
+                WriteIndent(builder, indentLevel, indentation);
+                builder.Append(clauseText);
+                currentClause = clauseText;
+
+                if (ListClauses.Contains(clauseText))
+                {
+                    listClauseIndent = indentLevel + 1;
+                    AppendNewLine(builder, ref lineStart, ref pendingSpace);
+                }
+                else
+                {
+                    listClauseIndent = -1;
+                    pendingSpace = true;
+                    lineStart = false;
+                }
+
+                i += consumed - 1;
+                continue;
+            }
+
+            var upper = token.UpperText;
+
+            if (BreakLogicalOperators.Contains(upper) &&
+                (currentClause.Equals("WHERE", StringComparison.OrdinalIgnoreCase) ||
+                 currentClause.Equals("ON", StringComparison.OrdinalIgnoreCase) ||
+                 currentClause.Equals("HAVING", StringComparison.OrdinalIgnoreCase)))
+            {
+                AppendNewLine(builder, ref lineStart, ref pendingSpace);
+                WriteIndent(builder, indentLevel + 1, indentation);
+                builder.Append(token.Text);
+                pendingSpace = true;
+                lineStart = false;
+                continue;
+            }
+
+            if (token.Text == ",")
+            {
+                builder.Append(',');
+                if (listClauseIndent >= 0)
+                {
+                    AppendNewLine(builder, ref lineStart, ref pendingSpace);
+                }
+                else
+                {
+                    pendingSpace = true;
+                }
+
+                continue;
+            }
+
+            if (token.Text == ".")
+            {
+                builder.Append('.');
+                pendingSpace = false;
+                lineStart = false;
+                continue;
+            }
+
+            if (token.Text == "(")
+            {
+                if (pendingSpace && !lineStart)
+                    builder.Append(' ');
+
+                builder.Append('(');
+                pendingSpace = false;
+                lineStart = false;
+                indentLevel++;
+                continue;
+            }
+
+            if (token.Text == ")")
+            {
+                indentLevel = Math.Max(0, indentLevel - 1);
+                if (lineStart)
+                    WriteIndent(builder, indentLevel, indentation);
+
+                builder.Append(')');
+                pendingSpace = true;
+                lineStart = false;
+                continue;
+            }
+
+            if (token.Text == ";")
+            {
+                builder.Append(';');
+                AppendNewLine(builder, ref lineStart, ref pendingSpace);
+                currentClause = string.Empty;
+                listClauseIndent = -1;
+                continue;
+            }
+
+            if (Operators.Contains(token.Text))
+            {
+                if (!lineStart && builder.Length > 0 && builder[^1] != ' ')
+                    builder.Append(' ');
+
+                builder.Append(token.Text);
+                builder.Append(' ');
+                pendingSpace = false;
+                lineStart = false;
+                continue;
+            }
+
+            if (lineStart)
+            {
+                WriteIndent(builder, listClauseIndent >= 0 ? listClauseIndent : indentLevel, indentation);
+                lineStart = false;
+            }
+            else if (pendingSpace)
+            {
+                builder.Append(' ');
+            }
+
+            builder.Append(token.Text);
+            pendingSpace = NeedsSpaceAfter(token.Text);
+        }
+
+        return NormalizeOutput(builder.ToString());
+    }
+
+    private static List<SqlFormatToken> TryTokenize(string sql, DatabaseType databaseType)
+    {
+        Lexer? lexer = databaseType switch
+        {
+            DatabaseType.SqlServer => new TSqlLexer(new AntlrInputStream(sql)),
+            DatabaseType.MySql => new MySQLLexer(new AntlrInputStream(sql)),
+            _ => null
+        };
+
+        if (lexer is null)
+            return TokenizeFallback(sql);
+
+        var tokens = new List<SqlFormatToken>();
+        while (true)
+        {
+            var token = lexer.NextToken();
+            if (token.Type == TokenConstants.EOF)
+                break;
+
+            if (token.Channel == Lexer.Hidden)
+            {
+                if (IsComment(token.Text))
+                    tokens.Add(new SqlFormatToken(token.Text, SqlFormatTokenKind.Comment));
+
+                continue;
+            }
+
+            tokens.Add(new SqlFormatToken(token.Text, SqlFormatTokenKind.Code));
+        }
+
+        return tokens;
+    }
+
+    private static List<SqlFormatToken> TokenizeFallback(string sql)
+    {
+        return sql.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => new SqlFormatToken(part, SqlFormatTokenKind.Code))
+            .ToList();
+    }
+
+    private static bool TryReadClause(IReadOnlyList<SqlFormatToken> tokens, int index, out string clauseText, out int consumed)
+    {
+        clauseText = tokens[index].Text;
+        consumed = 1;
+        if (tokens[index].Kind != SqlFormatTokenKind.Code)
+            return false;
+
+        var single = tokens[index].UpperText;
+        if (MajorClauses.Contains(single))
+        {
+            clauseText = tokens[index].Text;
+            return true;
+        }
+
+        if (index + 1 >= tokens.Count || tokens[index + 1].Kind != SqlFormatTokenKind.Code)
+            return false;
+
+        var combined = $"{single} {tokens[index + 1].UpperText}";
+        if (MajorClauses.Contains(combined))
+        {
+            clauseText = $"{tokens[index].Text} {tokens[index + 1].Text}";
+            consumed = 2;
+            return true;
+        }
+
+        if (index + 2 >= tokens.Count || tokens[index + 2].Kind != SqlFormatTokenKind.Code)
+            return false;
+
+        var triple = $"{combined} {tokens[index + 2].UpperText}";
+        if (!MajorClauses.Contains(triple))
+            return false;
+
+        clauseText = $"{tokens[index].Text} {tokens[index + 1].Text} {tokens[index + 2].Text}";
+        consumed = 3;
+        return true;
+    }
+
+    private static bool IsComment(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+
+        var trimmed = text.TrimStart();
+        return trimmed.StartsWith("--", StringComparison.Ordinal) ||
+               trimmed.StartsWith("/*", StringComparison.Ordinal) ||
+               trimmed.StartsWith("#", StringComparison.Ordinal);
+    }
+
+    private static bool NeedsSpaceAfter(string token)
+    {
+        return token is not "(" and not "." and not "::";
+    }
+
+    private static void EnsureLineStart(StringBuilder builder, ref bool lineStart, ref bool pendingSpace)
+    {
+        if (!lineStart)
+            AppendNewLine(builder, ref lineStart, ref pendingSpace);
+    }
+
+    private static void AppendNewLine(StringBuilder builder, ref bool lineStart, ref bool pendingSpace)
+    {
+        if (builder.Length == 0 || builder[^1] == '\n')
+        {
+            lineStart = true;
+            pendingSpace = false;
+            return;
+        }
+
+        builder.Append('\n');
+        lineStart = true;
+        pendingSpace = false;
+    }
+
+    private static void WriteIndent(StringBuilder builder, int indentLevel, string indentation)
+    {
+        for (var i = 0; i < indentLevel; i++)
+            builder.Append(indentation);
+    }
+
+    private static string NormalizeOutput(string text)
+    {
+        var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n');
+        var builder = new StringBuilder(text.Length);
+        var previousBlank = false;
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            var isBlank = line.Length == 0;
+            if (isBlank && previousBlank)
+                continue;
+
+            if (builder.Length > 0)
+                builder.Append('\n');
+
+            builder.Append(line);
+            previousBlank = isBlank;
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private enum SqlFormatTokenKind
+    {
+        Code,
+        Comment
+    }
+
+    private readonly record struct SqlFormatToken(string Text, SqlFormatTokenKind Kind)
+    {
+        public string UpperText { get; } = Text.ToUpperInvariant();
+    }
+}

--- a/DataDeveloper/ViewModels/MainWindowViewModel.cs
+++ b/DataDeveloper/ViewModels/MainWindowViewModel.cs
@@ -3,10 +3,15 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Reactive;
-using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using AvaloniaEdit;
+using AvaloniaEdit.Search;
 using DataDeveloper.Core;
+using DataDeveloper.Data.Enums;
 using DataDeveloper.EventAggregators;
 using DataDeveloper.Interfaces;
 using DataDeveloper.Services;
@@ -23,12 +28,18 @@ public class MainWindowViewModel : ViewModelBase
     private readonly IConnectionDialogService _connectionDialogService;
     private readonly IEventAggregatorService _eventAggregatorService;
     private readonly IDialogService _dialogService;
+    private readonly IReleaseUpdateService _releaseUpdateService;
+    private readonly KeyModifiers _primaryShortcutModifier = OperatingSystem.IsMacOS() ? KeyModifiers.Meta : KeyModifiers.Control;
+    private TextEditor? _activeEditor;
+    private DatabaseType _activeDatabaseType;
+
     public MainWindowViewModel(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
         _connectionDialogService = _serviceProvider.GetRequiredService<IConnectionDialogService>();
         _eventAggregatorService = _serviceProvider.GetRequiredService<IEventAggregatorService>();
         _dialogService = _serviceProvider.GetRequiredService<IDialogService>();
+        _releaseUpdateService = _serviceProvider.GetRequiredService<IReleaseUpdateService>();
         
         _eventAggregatorService.Subscribe<ShowCursorDataEvent>(this, ShowCursorDataEvent);
         _eventAggregatorService.Subscribe<ShowExecutionStatusEvent>(this, ShowExecutionStatusEvent);
@@ -37,10 +48,25 @@ public class MainWindowViewModel : ViewModelBase
         this.NewConnectionCommand = ReactiveCommand.CreateFromTask<StyledElement>(NewConnection);
         this.CloseTabConnectionCommand = ReactiveCommand.CreateFromTask<TabConnectionViewModel, bool>(CloseTabConnection);
         
-        this.NewQueryTabCommand = ReactiveCommand.CreateFromTask(NewQueryTab);
-        this.OpenFileCommand = ReactiveCommand.CreateFromTask(OpenFile);
-        this.SaveCurrentEditorTabCommand = ReactiveCommand.CreateFromTask(() => SaveCurrentEditorTab());
-        this.SaveAsCurrentEditorTabCommand = ReactiveCommand.CreateFromTask(() => SaveCurrentEditorTab(isSaveAs: true));
+        this.NewQueryTabCommand = ReactiveCommand.CreateFromTask(NewQueryTab, this.WhenAnyValue(vm => vm.HasConnections));
+        this.OpenFileCommand = ReactiveCommand.CreateFromTask(OpenFile, this.WhenAnyValue(vm => vm.HasConnections));
+        this.SaveCurrentEditorTabCommand = ReactiveCommand.CreateFromTask(() => SaveCurrentEditorTab(), this.WhenAnyValue(vm => vm.HasEditor));
+        this.SaveAsCurrentEditorTabCommand = ReactiveCommand.CreateFromTask(() => SaveCurrentEditorTab(isSaveAs: true), this.WhenAnyValue(vm => vm.HasEditor));
+        this.AboutCommand = ReactiveCommand.CreateFromTask(ShowAboutAsync);
+        this.CutCommand = ReactiveCommand.Create(Cut, this.WhenAnyValue(vm => vm.CanCut));
+        this.CopyCommand = ReactiveCommand.Create(Copy, this.WhenAnyValue(vm => vm.CanCopy));
+        this.PasteCommand = ReactiveCommand.Create(Paste, this.WhenAnyValue(vm => vm.CanPaste));
+        this.UndoCommand = ReactiveCommand.Create(Undo, this.WhenAnyValue(vm => vm.CanUndo));
+        this.RedoCommand = ReactiveCommand.Create(Redo, this.WhenAnyValue(vm => vm.CanRedo));
+        this.FindCommand = ReactiveCommand.Create(Find, this.WhenAnyValue(vm => vm.HasActiveEditor));
+        this.ReplaceCommand = ReactiveCommand.Create(Replace, this.WhenAnyValue(vm => vm.HasActiveEditor));
+        this.UpperCommand = ReactiveCommand.Create(Upper, this.WhenAnyValue(vm => vm.HasSelection));
+        this.LowerCommand = ReactiveCommand.Create(Lower, this.WhenAnyValue(vm => vm.HasSelection));
+        this.BeautifyCommand = ReactiveCommand.Create(Beautify, this.WhenAnyValue(vm => vm.HasActiveEditor));
+        this.IndentCommand = ReactiveCommand.Create(Indent, this.WhenAnyValue(vm => vm.HasActiveEditor));
+        this.UnindentCommand = ReactiveCommand.Create(Unindent, this.WhenAnyValue(vm => vm.HasActiveEditor));
+        this.CommentCommand = ReactiveCommand.Create(Comment, this.WhenAnyValue(vm => vm.HasSelection));
+        this.UncommentCommand = ReactiveCommand.Create(Uncomment, this.WhenAnyValue(vm => vm.HasSelection));
         
         this.WhenAnyValue(vm => vm.SelectedTabConnectionIndex).Subscribe(_ => OnSelectedTabConnectionIndexChanged());
     }
@@ -60,6 +86,9 @@ public class MainWindowViewModel : ViewModelBase
 
     private async Task SaveCurrentEditorTab(bool isSaveAs = false)
     {
+        if (GetCurrentTabQueryEditorViewModel() is null)
+            return;
+
         var connection = this.Connections[this.SelectedTabConnectionIndex];
         var queryEditor = connection.QueryEditors[connection.SelectedEditor];
 
@@ -71,17 +100,23 @@ public class MainWindowViewModel : ViewModelBase
 
     private async Task OpenFile()
     {
+        if (!HasConnections)
+            return;
+
         var fileToOpen = await _dialogService.ShowOpenFileAsync();
         if (fileToOpen != null)
         {
-            await this.Connections[this.SelectedTabConnectionIndex].AddQueryEditorCommand.Execute(fileToOpen);
+            await this.Connections[this.SelectedTabConnectionIndex].AddQueryEditorCommand.Execute(fileToOpen).ToTask();
         }
 
     }
 
     private async Task NewQueryTab()
     {
-        await this.Connections[this.SelectedTabConnectionIndex].AddQueryEditorCommand.Execute();
+        if (!HasConnections)
+            return;
+
+        await this.Connections[this.SelectedTabConnectionIndex].AddQueryEditorCommand.Execute().ToTask();
     }
 
     private async Task<bool> CloseTabConnection(TabConnectionViewModel connection)
@@ -93,13 +128,16 @@ public class MainWindowViewModel : ViewModelBase
             connection.SelectedEditor = indexQueryEditor;
             await Task.Delay(100);
             var queryEditor = connection.QueryEditors[indexQueryEditor];
-            if (!(await connection.CloseTabQueryEditorCommand.Execute(queryEditor)))
+            if (!(await connection.CloseTabQueryEditorCommand.Execute(queryEditor).ToTask()))
                 break;
             countClosed++;
         }
 
         if (countClosed == count)
             Connections.Remove(connection);
+
+        this.RaisePropertyChanged(nameof(HasConnections));
+        this.RaisePropertyChanged(nameof(HasEditor));
         
         return countClosed == count;
     }
@@ -109,6 +147,21 @@ public class MainWindowViewModel : ViewModelBase
     public ReactiveCommand<Unit, Unit> OpenFileCommand { get; }
     public ReactiveCommand<Unit, Unit> SaveCurrentEditorTabCommand { get; }
     public ReactiveCommand<Unit, Unit> SaveAsCurrentEditorTabCommand { get; }
+    public ReactiveCommand<Unit, Unit> AboutCommand { get; }
+    public ReactiveCommand<Unit, Unit> CutCommand { get; }
+    public ReactiveCommand<Unit, Unit> CopyCommand { get; }
+    public ReactiveCommand<Unit, Unit> PasteCommand { get; }
+    public ReactiveCommand<Unit, Unit> UndoCommand { get; }
+    public ReactiveCommand<Unit, Unit> RedoCommand { get; }
+    public ReactiveCommand<Unit, Unit> FindCommand { get; }
+    public ReactiveCommand<Unit, Unit> ReplaceCommand { get; }
+    public ReactiveCommand<Unit, Unit> UpperCommand { get; }
+    public ReactiveCommand<Unit, Unit> LowerCommand { get; }
+    public ReactiveCommand<Unit, Unit> BeautifyCommand { get; }
+    public ReactiveCommand<Unit, Unit> IndentCommand { get; }
+    public ReactiveCommand<Unit, Unit> UnindentCommand { get; }
+    public ReactiveCommand<Unit, Unit> CommentCommand { get; }
+    public ReactiveCommand<Unit, Unit> UncommentCommand { get; }
     public ReactiveCommand<TabConnectionViewModel, bool> CloseTabConnectionCommand { get; }
     public ReactiveCommand<StyledElement, Unit> NewConnectionCommand { get; }
     public ObservableCollection<TabConnectionViewModel> Connections { get; } =  new();
@@ -118,6 +171,33 @@ public class MainWindowViewModel : ViewModelBase
     [Reactive] public int CursorColumn { get; set; }
     [Reactive] public bool IsExecutionStatusVisible { get; set; }
     [Reactive] public string ExecutionStatusMessage { get; set; } = string.Empty;
+    [Reactive] public bool HasActiveEditor { get; private set; }
+    [Reactive] public bool HasSelection { get; private set; }
+    [Reactive] public bool CanCut { get; private set; }
+    [Reactive] public bool CanCopy { get; private set; }
+    [Reactive] public bool CanPaste { get; private set; }
+    [Reactive] public bool CanUndo { get; private set; }
+    [Reactive] public bool CanRedo { get; private set; }
+    public KeyGesture OpenFileGesture => CreatePrimaryGesture(Key.O);
+    public KeyGesture SaveGesture => CreatePrimaryGesture(Key.S);
+    public KeyGesture SaveAsGesture => CreatePrimaryGesture(Key.S, KeyModifiers.Shift);
+    public KeyGesture NewQueryTabGesture => CreatePrimaryGesture(Key.T);
+    public KeyGesture CutGesture => CreatePrimaryGesture(Key.X);
+    public KeyGesture CopyGesture => CreatePrimaryGesture(Key.C);
+    public KeyGesture PasteGesture => CreatePrimaryGesture(Key.V);
+    public KeyGesture UndoGesture => CreatePrimaryGesture(Key.Z);
+    public KeyGesture RedoGesture => CreatePrimaryGesture(Key.Y);
+    public KeyGesture FindGesture => CreatePrimaryGesture(Key.F);
+    public KeyGesture ReplaceGesture => CreatePrimaryGesture(Key.H);
+    public KeyGesture UpperGesture => CreatePrimaryGesture(Key.U, KeyModifiers.Shift);
+    public KeyGesture LowerGesture => CreatePrimaryGesture(Key.U);
+    public KeyGesture BeautifyGesture => CreatePrimaryGesture(Key.B);
+    public KeyGesture IndentGesture => new(Key.Tab);
+    public KeyGesture UnindentGesture => new(Key.Tab, KeyModifiers.Shift);
+    public KeyGesture CommentGesture => CreatePrimaryGesture(Key.K);
+    public KeyGesture UncommentGesture => CreatePrimaryGesture(Key.K, KeyModifiers.Shift);
+    public bool UsesMacShortcuts => OperatingSystem.IsMacOS();
+    public bool ShowHelpMenu => !OperatingSystem.IsMacOS();
 
     public bool HasConnections
     {
@@ -137,12 +217,168 @@ public class MainWindowViewModel : ViewModelBase
         var connection = Connections[this.SelectedTabConnectionIndex];
         var queryEditor = connection.QueryEditors[connection.SelectedEditor];
         queryEditor.ShowCursorData();
+        this.RaisePropertyChanged(nameof(HasConnections));
+        this.RaisePropertyChanged(nameof(HasEditor));
     }
 
     private void NewWindow()
     {
         var newWindow = (MainWindow)_serviceProvider.CreateScope().ServiceProvider.GetRequiredService<IMainWindow>();
         newWindow.Show();
+    }
+
+    private async Task ShowAboutAsync()
+    {
+        var version = ApplicationVersionHelper.GetCurrentVersion(typeof(MainWindowViewModel).Assembly);
+        await _dialogService.ShowAboutAsync(version, () => _releaseUpdateService.CheckForUpdatesAsync());
+    }
+
+    public void SetActiveEditor(TextEditor editor, DatabaseType databaseType)
+    {
+        _activeEditor = editor;
+        _activeDatabaseType = databaseType;
+        RefreshActiveEditorState();
+    }
+
+    public void ClearActiveEditor(TextEditor editor)
+    {
+        if (!ReferenceEquals(_activeEditor, editor))
+            return;
+
+        _activeEditor = null;
+        RefreshActiveEditorState();
+    }
+
+    public void RefreshActiveEditorState()
+    {
+        HasActiveEditor = _activeEditor is not null;
+        HasSelection = _activeEditor?.SelectionLength > 0;
+        CanCut = _activeEditor?.CanCut == true;
+        CanCopy = _activeEditor?.CanCopy == true;
+        CanPaste = _activeEditor is not null;
+        CanUndo = _activeEditor?.CanUndo == true;
+        CanRedo = _activeEditor?.CanRedo == true;
+        this.RaisePropertyChanged(nameof(HasEditor));
+        this.RaisePropertyChanged(nameof(HasConnections));
+    }
+
+    private void Cut()
+    {
+        if (_activeEditor?.CanCut == true)
+            _activeEditor.Cut();
+
+        RefreshActiveEditorState();
+    }
+
+    private void Copy()
+    {
+        if (_activeEditor?.CanCopy == true)
+            _activeEditor.Copy();
+    }
+
+    private void Paste()
+    {
+        if (_activeEditor?.CanPaste == true)
+            _activeEditor.Paste();
+    }
+
+    private void Undo()
+    {
+        if (_activeEditor?.CanUndo == true)
+            _activeEditor.Undo();
+
+        RefreshActiveEditorState();
+    }
+
+    private void Redo()
+    {
+        if (_activeEditor?.CanRedo == true)
+            _activeEditor.Redo();
+
+        RefreshActiveEditorState();
+    }
+
+    private void Find()
+    {
+        if (_activeEditor is null)
+            return;
+
+        var panel = SearchPanel.Install(_activeEditor);
+        InitializeSearchPattern(_activeEditor, panel);
+        panel.IsReplaceMode = false;
+        panel.Open();
+        panel.Reactivate();
+    }
+
+    private void Replace()
+    {
+        if (_activeEditor is null)
+            return;
+
+        var panel = SearchPanel.Install(_activeEditor);
+        InitializeSearchPattern(_activeEditor, panel);
+        panel.IsReplaceMode = true;
+        panel.Open();
+        panel.Reactivate();
+    }
+
+    private void Upper()
+    {
+        if (_activeEditor is null)
+            return;
+
+        ApplyTextEdit(_activeEditor, SqlEditorTextOperations.ToUpper(_activeEditor.Text ?? string.Empty, _activeEditor.SelectionStart, _activeEditor.SelectionLength));
+    }
+
+    private void Lower()
+    {
+        if (_activeEditor is null)
+            return;
+
+        ApplyTextEdit(_activeEditor, SqlEditorTextOperations.ToLower(_activeEditor.Text ?? string.Empty, _activeEditor.SelectionStart, _activeEditor.SelectionLength));
+    }
+
+    private void Beautify()
+    {
+        if (_activeEditor is null)
+            return;
+
+        var indentation = GetIndentation(_activeEditor);
+        ApplyTextEdit(_activeEditor, SqlEditorTextOperations.Beautify(_activeEditor.Text ?? string.Empty, _activeEditor.SelectionStart, _activeEditor.SelectionLength, indentation, _activeDatabaseType));
+    }
+
+    private void Indent()
+    {
+        if (_activeEditor is null)
+            return;
+
+        var indentation = GetIndentation(_activeEditor);
+        ApplyTextEdit(_activeEditor, SqlEditorTextOperations.Indent(_activeEditor.Text ?? string.Empty, _activeEditor.SelectionStart, _activeEditor.SelectionLength, indentation));
+    }
+
+    private void Unindent()
+    {
+        if (_activeEditor is null)
+            return;
+
+        var indentation = GetIndentation(_activeEditor);
+        ApplyTextEdit(_activeEditor, SqlEditorTextOperations.Unindent(_activeEditor.Text ?? string.Empty, _activeEditor.SelectionStart, _activeEditor.SelectionLength, indentation));
+    }
+
+    private void Comment()
+    {
+        if (_activeEditor is null)
+            return;
+
+        ApplyTextEdit(_activeEditor, SqlEditorTextOperations.Comment(_activeEditor.Text ?? string.Empty, _activeEditor.SelectionStart, _activeEditor.SelectionLength));
+    }
+
+    private void Uncomment()
+    {
+        if (_activeEditor is null)
+            return;
+
+        ApplyTextEdit(_activeEditor, SqlEditorTextOperations.Uncomment(_activeEditor.Text ?? string.Empty, _activeEditor.SelectionStart, _activeEditor.SelectionLength));
     }
 
     private async Task NewConnection(StyledElement control)
@@ -158,6 +394,8 @@ public class MainWindowViewModel : ViewModelBase
                 var tab = new TabConnectionViewModel(connectionSettings, true, _serviceProvider);
                 Connections.Add(tab);
                 SelectedTabConnectionIndex = Connections.Count - 1;
+                this.RaisePropertyChanged(nameof(HasConnections));
+                this.RaisePropertyChanged(nameof(HasEditor));
             }
         }
         catch (Exception e)
@@ -177,5 +415,54 @@ public class MainWindowViewModel : ViewModelBase
     {
         IsExecutionStatusVisible = message.IsVisible;
         ExecutionStatusMessage = message.Message;
+    }
+
+    private static void InitializeSearchPattern(TextEditor editor, SearchPanel panel)
+    {
+        if (!string.IsNullOrWhiteSpace(editor.SelectedText))
+            panel.SearchPattern = editor.SelectedText;
+    }
+
+    private static string GetIndentation(TextEditor editor)
+    {
+        var options = editor.Options;
+        if (options.ConvertTabsToSpaces)
+            return new string(' ', Math.Max(1, options.IndentationSize));
+
+        return string.IsNullOrEmpty(options.IndentationString)
+            ? "\t"
+            : options.IndentationString;
+    }
+
+    private static void ApplyTextEdit(TextEditor editor, TextEditResult? edit)
+    {
+        if (edit is null || editor.Document is null)
+            return;
+
+        using (editor.Document.RunUpdate())
+        {
+            editor.Document.Replace(edit.Value.ReplaceStart, edit.Value.ReplaceLength, edit.Value.ReplacementText);
+        }
+
+        if (edit.Value.SelectionLength == 0)
+        {
+            editor.SelectionLength = 0;
+            editor.SelectionStart = edit.Value.SelectionStart;
+            editor.Focus();
+            return;
+        }
+
+        editor.Select(edit.Value.SelectionStart, edit.Value.SelectionLength);
+        editor.Focus();
+    }
+
+    private KeyGesture CreatePrimaryGesture(Key key, KeyModifiers modifiers = KeyModifiers.None)
+    {
+        return new KeyGesture(key, _primaryShortcutModifier | modifiers);
+    }
+
+    public bool HasPrimaryShortcutModifier(KeyEventArgs e)
+    {
+        return e.KeyModifiers.HasFlag(_primaryShortcutModifier);
     }
 }

--- a/DataDeveloper/Views/AboutWindow.axaml
+++ b/DataDeveloper/Views/AboutWindow.axaml
@@ -1,0 +1,46 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="DataDeveloper.Views.AboutWindow"
+        Width="420"
+        SizeToContent="Height"
+        CanResize="False"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner"
+        Title="About Data Developer">
+    <Border Padding="24" Background="#FF25282E" BorderBrush="#FF3A404A" BorderThickness="1">
+        <Grid RowDefinitions="Auto,Auto,Auto" RowSpacing="20">
+            <StackPanel Spacing="8">
+                <TextBlock Text="Data Developer"
+                           FontSize="24"
+                           FontWeight="SemiBold"
+                           Foreground="#FFF6F7FB" />
+                <TextBlock x:Name="VersionText"
+                           FontSize="14"
+                           Foreground="#FFD6DAE2" />
+            </StackPanel>
+
+            <TextBlock Grid.Row="1"
+                       Text="A lightweight SQL workspace."
+                       FontSize="13"
+                       Foreground="#FFADB5C3" />
+
+            <StackPanel Grid.Row="2"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="10">
+                <Button x:Name="CheckForUpdatesButton"
+                        Classes="dialog-button"
+                        Content="Check for updates"
+                        MinWidth="148"
+                        Click="OnCheckForUpdatesClick" />
+                <Button x:Name="OkButton"
+                        Classes="dialog-button primary"
+                        Content="OK"
+                        MinWidth="92"
+                        IsDefault="True"
+                        IsCancel="True"
+                        Click="OnOkClick" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</Window>

--- a/DataDeveloper/Views/AboutWindow.axaml.cs
+++ b/DataDeveloper/Views/AboutWindow.axaml.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+
+namespace DataDeveloper.Views;
+
+public partial class AboutWindow : Window
+{
+    private readonly Func<Task> _checkForUpdatesAsync;
+
+    public AboutWindow()
+    {
+        InitializeComponent();
+        _checkForUpdatesAsync = () => Task.CompletedTask;
+    }
+
+    public AboutWindow(string version, Func<Task> checkForUpdatesAsync)
+        : this()
+    {
+        VersionText.Text = $"Version {version}";
+        _checkForUpdatesAsync = checkForUpdatesAsync;
+    }
+
+    private void OnOkClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private async void OnCheckForUpdatesClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        CheckForUpdatesButton.IsEnabled = false;
+        try
+        {
+            await _checkForUpdatesAsync();
+        }
+        finally
+        {
+            CheckForUpdatesButton.IsEnabled = true;
+        }
+    }
+}

--- a/DataDeveloper/Views/AppDialogWindow.axaml.cs
+++ b/DataDeveloper/Views/AppDialogWindow.axaml.cs
@@ -41,18 +41,13 @@ public partial class AppDialogWindow : Window
             Content = button.Label,
             Tag = button.Result,
             MinWidth = 96,
-            Padding = new Thickness(18, 10),
             Margin = new Thickness(8, 0, 0, 0),
-            CornerRadius = new CornerRadius(10),
-            Foreground = Brushes.White,
-            HorizontalContentAlignment = HorizontalAlignment.Center,
-            VerticalContentAlignment = VerticalAlignment.Center,
-            BorderThickness = new Thickness(1),
-            BorderBrush = new SolidColorBrush(Color.Parse(button.IsPrimary ? "#FF5F7FE3" : "#FF4A505C")),
-            Background = new SolidColorBrush(Color.Parse(button.IsPrimary ? "#FF4D6DD1" : "#FF343A44")),
             IsDefault = button.IsDefault,
             IsCancel = button.IsCancel
         };
+        control.Classes.Add("dialog-button");
+        if (button.IsPrimary)
+            control.Classes.Add("primary");
         control.Click += OnButtonClick;
         if (button.IsDefault)
             _defaultButton = control;

--- a/DataDeveloper/Views/MainView.axaml
+++ b/DataDeveloper/Views/MainView.axaml
@@ -19,12 +19,36 @@
             <MenuItem Header="_File">
                 <MenuItem Header="_Load/Add connection" Command="{Binding NewConnectionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />
                 <Separator />
-                <MenuItem Header="_Open" Command="{Binding OpenFileCommand}" />
-                <MenuItem Header="_Save..." Command="{Binding SaveCurrentEditorTabCommand}" />
-                <MenuItem Header="Save as..." Command="{Binding SaveAsCurrentEditorTabCommand}" />
+                <MenuItem Header="_Open" Command="{Binding OpenFileCommand}" InputGesture="{Binding OpenFileGesture}" HotKey="{Binding OpenFileGesture}" />
+                <MenuItem Header="_Save..." Command="{Binding SaveCurrentEditorTabCommand}" InputGesture="{Binding SaveGesture}" HotKey="{Binding SaveGesture}" />
+                <MenuItem Header="Save as..." Command="{Binding SaveAsCurrentEditorTabCommand}" InputGesture="{Binding SaveAsGesture}" HotKey="{Binding SaveAsGesture}" />
                 <Separator />
-                <MenuItem Header="_New query tab" Command="{Binding NewQueryTabCommand}" />
+                <MenuItem Header="_New query tab" Command="{Binding NewQueryTabCommand}" InputGesture="{Binding NewQueryTabGesture}" HotKey="{Binding NewQueryTabGesture}" />
                 <MenuItem Header="New Window" Command="{Binding NewWindowCommand}"/>
+            </MenuItem>
+            <MenuItem Header="_Edit">
+                <MenuItem Header="Cu_t" Command="{Binding CutCommand}" InputGesture="{Binding CutGesture}" HotKey="{Binding CutGesture}" />
+                <MenuItem Header="_Copy" Command="{Binding CopyCommand}" InputGesture="{Binding CopyGesture}" HotKey="{Binding CopyGesture}" />
+                <MenuItem Header="_Paste" Command="{Binding PasteCommand}" InputGesture="{Binding PasteGesture}" HotKey="{Binding PasteGesture}" />
+                <Separator />
+                <MenuItem Header="_Undo" Command="{Binding UndoCommand}" InputGesture="{Binding UndoGesture}" HotKey="{Binding UndoGesture}" />
+                <MenuItem Header="_Redo" Command="{Binding RedoCommand}" InputGesture="{Binding RedoGesture}" HotKey="{Binding RedoGesture}" />
+                <Separator />
+                <MenuItem Header="_Find" Command="{Binding FindCommand}" InputGesture="{Binding FindGesture}" HotKey="{Binding FindGesture}" />
+                <MenuItem Header="_Replace" Command="{Binding ReplaceCommand}" InputGesture="{Binding ReplaceGesture}" HotKey="{Binding ReplaceGesture}" />
+                <Separator />
+                <MenuItem Header="UPPER" Command="{Binding UpperCommand}" InputGesture="{Binding UpperGesture}" HotKey="{Binding UpperGesture}" />
+                <MenuItem Header="lower" Command="{Binding LowerCommand}" InputGesture="{Binding LowerGesture}" HotKey="{Binding LowerGesture}" />
+                <MenuItem Header="_Beautify" Command="{Binding BeautifyCommand}" InputGesture="{Binding BeautifyGesture}" HotKey="{Binding BeautifyGesture}" />
+                <Separator />
+                <MenuItem Header="_Indent" Command="{Binding IndentCommand}" InputGesture="{Binding IndentGesture}" HotKey="{Binding IndentGesture}" />
+                <MenuItem Header="U_nindent" Command="{Binding UnindentCommand}" InputGesture="{Binding UnindentGesture}" HotKey="{Binding UnindentGesture}" />
+                <Separator />
+                <MenuItem Header="_Comment" Command="{Binding CommentCommand}" InputGesture="{Binding CommentGesture}" HotKey="{Binding CommentGesture}" />
+                <MenuItem Header="U_ncomment" Command="{Binding UncommentCommand}" InputGesture="{Binding UncommentGesture}" HotKey="{Binding UncommentGesture}" />
+            </MenuItem>
+            <MenuItem Header="_Help" IsVisible="{Binding ShowHelpMenu}">
+                <MenuItem Header="_About Data Developer" Command="{Binding AboutCommand}" />
             </MenuItem>
         </Menu>
         <Button Grid.Row="0" Grid.Column="2" HorizontalAlignment="Right" Margin = "0,0,5,0" Content="Load/Add connection" Command="{Binding NewConnectionCommand}" CommandParameter="{Binding RelativeSource={RelativeSource Self}}" />

--- a/DataDeveloper/Views/MainWindow.axaml
+++ b/DataDeveloper/Views/MainWindow.axaml
@@ -4,5 +4,11 @@
         x:Class="DataDeveloper.Views.MainWindow"
         Title="Data Developer"
         Width="1000" Height="700">
+    <Window.KeyBindings>
+        <KeyBinding Gesture="{Binding OpenFileGesture}" Command="{Binding OpenFileCommand}" />
+        <KeyBinding Gesture="{Binding SaveGesture}" Command="{Binding SaveCurrentEditorTabCommand}" />
+        <KeyBinding Gesture="{Binding SaveAsGesture}" Command="{Binding SaveAsCurrentEditorTabCommand}" />
+        <KeyBinding Gesture="{Binding NewQueryTabGesture}" Command="{Binding NewQueryTabCommand}" />
+    </Window.KeyBindings>
     <views:MainView />
 </Window>

--- a/DataDeveloper/Views/TabQueryEditorView.axaml.cs
+++ b/DataDeveloper/Views/TabQueryEditorView.axaml.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Specialized;
+using System.Collections.Generic;
+using System.Reactive;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Data;
@@ -13,6 +15,7 @@ using DataDeveloper.Models;
 using DataDeveloper.Services;
 using DataDeveloper.TemplateSelectors;
 using DataDeveloper.ViewModels;
+using ReactiveUI;
 
 namespace DataDeveloper.Views;
 
@@ -34,6 +37,10 @@ public partial class TabQueryEditorView : UserControl
         SqlEditor.TextArea.TextEntered += TextAreaOnTextEntered;
         SqlEditor.TextArea.TextEntering += TextAreaOnTextEntering;
         SqlEditor.TextArea.KeyDown += TextAreaOnKeyDown;
+        SqlEditor.GotFocus += SqlEditorOnGotFocus;
+        SqlEditor.TextChanged += SqlEditorOnStateChanged;
+        SqlEditor.TextArea.SelectionChanged += SqlEditorOnStateChanged;
+        Unloaded += OnUnloaded;
     }
 
     protected override void OnDataContextChanged(EventArgs e)
@@ -66,7 +73,14 @@ public partial class TabQueryEditorView : UserControl
         _viewModel.ResultsHeaderHeight = StackPanelResult.Bounds.Height;
         _viewModel.ShowResultTool += ViewModelOnShowResultTool;
         _viewModel.Tabs.CollectionChanged += TabsOnCollectionChanged;
+        ConfigureEditorContextMenu();
+        UpdateActiveEditorState();
         ApplyResultsPanelState();
+    }
+
+    private void OnUnloaded(object? sender, RoutedEventArgs e)
+    {
+        GetMainWindowViewModel()?.ClearActiveEditor(SqlEditor);
     }
 
     private void TabsOnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -175,7 +189,17 @@ public partial class TabQueryEditorView : UserControl
             var request = SqlCompletionProvider.GetManualCompletionRequest(SqlEditor.Text ?? string.Empty, SqlEditor.CaretOffset);
             await ShowCompletionAsync(request, rememberAsAutoRequest: false);
             e.Handled = true;
+            return;
         }
+
+        var mainWindowViewModel = GetMainWindowViewModel();
+        if (mainWindowViewModel is null)
+            return;
+
+        UpdateActiveEditorState();
+
+        if (TryHandleShortcut(e, mainWindowViewModel))
+            e.Handled = true;
     }
 
     private async Task ShowCompletionAsync(CompletionRequest request, bool rememberAsAutoRequest)
@@ -211,5 +235,123 @@ public partial class TabQueryEditorView : UserControl
             _completionInteractionState.ResetWhitespaceReopen();
         };
         _completionWindow.Show();
+    }
+
+    private void SqlEditorOnGotFocus(object? sender, GotFocusEventArgs e)
+    {
+        UpdateActiveEditorState();
+    }
+
+    private void SqlEditorOnStateChanged(object? sender, EventArgs e)
+    {
+        GetMainWindowViewModel()?.RefreshActiveEditorState();
+    }
+
+    private void UpdateActiveEditorState()
+    {
+        if (_viewModel is null)
+            return;
+
+        GetMainWindowViewModel()?.SetActiveEditor(SqlEditor, _viewModel.ConnectionSettings.DatabaseType);
+    }
+
+    private MainWindowViewModel? GetMainWindowViewModel()
+    {
+        return this.TryGetParentWindow()?.DataContext as MainWindowViewModel;
+    }
+
+    private void ConfigureEditorContextMenu()
+    {
+        var mainWindowViewModel = GetMainWindowViewModel();
+        if (mainWindowViewModel is null)
+            return;
+
+        var contextMenu = new ContextMenu();
+        contextMenu.Opening += (_, _) => UpdateActiveEditorState();
+
+        contextMenu.ItemsSource = BuildContextMenuItems(mainWindowViewModel);
+        SqlEditor.ContextMenu = contextMenu;
+    }
+
+    private static IReadOnlyList<object> BuildContextMenuItems(MainWindowViewModel viewModel)
+    {
+        return
+        [
+            CreateMenuItem("Cu_t", viewModel.CutCommand, viewModel.CutGesture),
+            CreateMenuItem("_Copy", viewModel.CopyCommand, viewModel.CopyGesture),
+            CreateMenuItem("_Paste", viewModel.PasteCommand, viewModel.PasteGesture),
+            new Separator(),
+            CreateMenuItem("_Undo", viewModel.UndoCommand, viewModel.UndoGesture),
+            CreateMenuItem("_Redo", viewModel.RedoCommand, viewModel.RedoGesture),
+            new Separator(),
+            CreateMenuItem("_Find", viewModel.FindCommand, viewModel.FindGesture),
+            CreateMenuItem("_Replace", viewModel.ReplaceCommand, viewModel.ReplaceGesture),
+            new Separator(),
+            CreateMenuItem("UPPER", viewModel.UpperCommand, viewModel.UpperGesture),
+            CreateMenuItem("lower", viewModel.LowerCommand, viewModel.LowerGesture),
+            CreateMenuItem("_Beautify", viewModel.BeautifyCommand, viewModel.BeautifyGesture),
+            new Separator(),
+            CreateMenuItem("_Indent", viewModel.IndentCommand, viewModel.IndentGesture),
+            CreateMenuItem("U_nindent", viewModel.UnindentCommand, viewModel.UnindentGesture),
+            new Separator(),
+            CreateMenuItem("_Comment", viewModel.CommentCommand, viewModel.CommentGesture),
+            CreateMenuItem("U_ncomment", viewModel.UncommentCommand, viewModel.UncommentGesture)
+        ];
+    }
+
+    private static MenuItem CreateMenuItem(string header, System.Windows.Input.ICommand command, KeyGesture inputGesture)
+    {
+        return new MenuItem
+        {
+            Header = header,
+            Command = command,
+            InputGesture = inputGesture
+        };
+    }
+
+    private static bool TryHandleShortcut(KeyEventArgs e, MainWindowViewModel viewModel)
+    {
+        if (!viewModel.HasPrimaryShortcutModifier(e))
+            return false;
+
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) && e.Key == Key.U && viewModel.HasSelection)
+        {
+            viewModel.UpperCommand.Execute().Subscribe();
+            return true;
+        }
+
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) && e.Key == Key.K && viewModel.HasSelection)
+        {
+            viewModel.UncommentCommand.Execute().Subscribe();
+            return true;
+        }
+
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift) && e.Key == Key.Tab && viewModel.HasActiveEditor)
+        {
+            viewModel.UnindentCommand.Execute().Subscribe();
+            return true;
+        }
+
+        return e.Key switch
+        {
+            Key.X when viewModel.CanCut => Execute(viewModel.CutCommand),
+            Key.C when viewModel.CanCopy => Execute(viewModel.CopyCommand),
+            Key.V when viewModel.CanPaste => Execute(viewModel.PasteCommand),
+            Key.Z when viewModel.CanUndo => Execute(viewModel.UndoCommand),
+            Key.Y when viewModel.CanRedo => Execute(viewModel.RedoCommand),
+            Key.F when viewModel.HasActiveEditor => Execute(viewModel.FindCommand),
+            Key.H when viewModel.HasActiveEditor => Execute(viewModel.ReplaceCommand),
+            Key.U when viewModel.HasSelection => Execute(viewModel.LowerCommand),
+            Key.B when viewModel.HasActiveEditor => Execute(viewModel.BeautifyCommand),
+            Key.K when viewModel.HasSelection => Execute(viewModel.CommentCommand),
+            Key.Tab when viewModel.HasActiveEditor => Execute(viewModel.IndentCommand),
+            _ => false
+        };
+    }
+
+    private static bool Execute(ReactiveCommand<Unit, Unit> command)
+    {
+        command.Execute().Subscribe();
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- add a full Edit menu integrated with the active AvaloniaEdit instance, including context-aware enablement, platform-specific shortcuts, and editor context menu actions
- add a Help/About flow with a simple About window and manual update checking, while keeping About only in the native app menu on macOS
- switch SQL beautify to token/lexer-based formatting for SQL Server and MySQL, add shared dialog button styles, and harden editor/window initialization edge cases

## Validation
- dotnet test DataDeveloper.sln

## Notes
- left the existing unrelated local change in  out of this commit