### PR TITLE
Add SQL Server Windows auth and database picker

### DIFF
--- a/DataDeveloper.Data/Interfaces/IDatabaseProvider.cs
+++ b/DataDeveloper.Data/Interfaces/IDatabaseProvider.cs
@@ -8,6 +8,7 @@ public interface IDatabaseProvider
 {
     DbConnection GetConnection();
     TestConnectionResult TestConnection();
+    IReadOnlyList<string> GetAvailableDatabaseNames();
     string GetTableStatement();
     string GetViewStatement();
     string GetColumnStatement();

--- a/DataDeveloper.Data/Providers/MySql/MySqlDatabaseProvider.cs
+++ b/DataDeveloper.Data/Providers/MySql/MySqlDatabaseProvider.cs
@@ -34,6 +34,21 @@ public class MySqlDatabaseProvider : DatabaseProviderBase<MySqlConnectionSetting
         return new MySqlConnection(connectionStringBuilder.ConnectionString);
     }
 
+    public override IReadOnlyList<string> GetAvailableDatabaseNames()
+    {
+        using var connection = new MySqlConnection(BuildConnectionString(string.Empty));
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+                              show databases;
+                              """;
+        using var reader = command.ExecuteReader();
+        var names = new List<string>();
+        while (reader.Read())
+            names.Add(reader.GetString(0));
+        return names;
+    }
+
     public override string GetTableStatement()
     {
         return """
@@ -126,5 +141,27 @@ public class MySqlDatabaseProvider : DatabaseProviderBase<MySqlConnectionSetting
                  and specific_name = @SpecificName
                order by ordinal_position;
                """;
+    }
+
+    private string BuildConnectionString(string? databaseName)
+    {
+        var sslMode = ConnectionSettings.Encrypt
+            ? ConnectionSettings.TrustServerCertificate
+                ? MySqlSslMode.Required
+                : MySqlSslMode.VerifyCA
+            : MySqlSslMode.None;
+
+        var connectionStringBuilder = new MySqlConnectionStringBuilder
+        {
+            Server = ConnectionSettings.Server,
+            Database = databaseName,
+            UserID = ConnectionSettings.User,
+            Password = ConnectionSettings.Password,
+            Port = ConnectionSettings.Port,
+            SslMode = sslMode,
+            AllowPublicKeyRetrieval = true
+        };
+
+        return connectionStringBuilder.ConnectionString;
     }
 }

--- a/DataDeveloper.Data/Providers/PostgresSql/PostgresDatabaseProvider.cs
+++ b/DataDeveloper.Data/Providers/PostgresSql/PostgresDatabaseProvider.cs
@@ -34,6 +34,25 @@ public class PostgresDatabaseProvider : DatabaseProviderBase<PostgresConnectionS
         return new NpgsqlConnection(connectionStringBuilder.ConnectionString);
     }
 
+    public override IReadOnlyList<string> GetAvailableDatabaseNames()
+    {
+        using var connection = new NpgsqlConnection(BuildConnectionString("postgres"));
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+                              select datname
+                              from pg_database
+                              where datallowconn
+                                and not datistemplate
+                              order by datname;
+                              """;
+        using var reader = command.ExecuteReader();
+        var names = new List<string>();
+        while (reader.Read())
+            names.Add(reader.GetString(0));
+        return names;
+    }
+
     public override string GetTableStatement()
     {
         return """
@@ -131,5 +150,27 @@ public class PostgresDatabaseProvider : DatabaseProviderBase<PostgresConnectionS
                  and specific_name = @SpecificName
                order by ordinal_position;
                """;
+    }
+
+    private string BuildConnectionString(string? databaseName)
+    {
+        var sslMode = ConnectionSettings.Encrypt
+            ? ConnectionSettings.TrustServerCertificate
+                ? SslMode.Require
+                : SslMode.VerifyCA
+            : SslMode.Disable;
+
+        var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+        {
+            Host = ConnectionSettings.Server,
+            Database = string.IsNullOrWhiteSpace(databaseName) ? "postgres" : databaseName,
+            Username = ConnectionSettings.User,
+            Password = ConnectionSettings.Password,
+            Port = ConnectionSettings.Port,
+            SslMode = sslMode,
+            TrustServerCertificate = ConnectionSettings.TrustServerCertificate
+        };
+
+        return connectionStringBuilder.ConnectionString;
     }
 }

--- a/DataDeveloper.Data/Providers/SqlServer/SqlServerAuthenticationMode.cs
+++ b/DataDeveloper.Data/Providers/SqlServer/SqlServerAuthenticationMode.cs
@@ -1,0 +1,7 @@
+namespace DataDeveloper.Data.Providers.SqlServer;
+
+public enum SqlServerAuthenticationMode
+{
+    SqlLogin = 0,
+    WindowsIntegrated = 1
+}

--- a/DataDeveloper.Data/Providers/SqlServer/SqlServerConnectionSettings.cs
+++ b/DataDeveloper.Data/Providers/SqlServer/SqlServerConnectionSettings.cs
@@ -7,4 +7,5 @@ public class SqlServerConnectionSettings : ConnectionSettings
 {
     [Reactive]public string Server { get; set; } = string.Empty;
     [Reactive]public string Database { get; set; } = string.Empty;
+    [Reactive]public SqlServerAuthenticationMode AuthenticationMode { get; set; } = SqlServerAuthenticationMode.SqlLogin;
 }

--- a/DataDeveloper.Data/Providers/SqlServer/SqlServerDatabaseProvider.cs
+++ b/DataDeveloper.Data/Providers/SqlServer/SqlServerDatabaseProvider.cs
@@ -16,15 +16,26 @@ public class SqlServerDatabaseProvider : DatabaseProviderBase<SqlServerConnectio
 
     public override DbConnection GetConnection()
     {
-        var connectionString =
-            $"Server={ConnectionSettings.Server};" +
-            $"Database={ConnectionSettings.Database};" +
-            $"User Id={ConnectionSettings.User};" +
-            $"Password={ConnectionSettings.Password};" +
-            $"Encrypt={ConnectionSettings.Encrypt};" +
-            $"TrustServerCertificate={ConnectionSettings.TrustServerCertificate};";
-        var conn = new SqlConnection(connectionString);
-        return conn;
+        return new SqlConnection(BuildConnectionString(ConnectionSettings.Database));
+    }
+
+    public override IReadOnlyList<string> GetAvailableDatabaseNames()
+    {
+        using var connection = new SqlConnection(BuildConnectionString("master"));
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+                              select name
+                              from sys.databases
+                              where state = 0
+                                and has_dbaccess(name) = 1
+                              order by name;
+                              """;
+        using var reader = command.ExecuteReader();
+        var names = new List<string>();
+        while (reader.Read())
+            names.Add(reader.GetString(0));
+        return names;
     }
 
     public override string GetTableStatement()
@@ -124,5 +135,28 @@ public class SqlServerDatabaseProvider : DatabaseProviderBase<SqlServerConnectio
                where concat(p.specific_schema, '.', p.specific_name) = @SpecificName
                order by p.ordinal_position;
                """;
+    }
+
+    private string BuildConnectionString(string? databaseName)
+    {
+        var builder = new SqlConnectionStringBuilder
+        {
+            DataSource = ConnectionSettings.Server,
+            InitialCatalog = string.IsNullOrWhiteSpace(databaseName) ? "master" : databaseName,
+            Encrypt = ConnectionSettings.Encrypt,
+            TrustServerCertificate = ConnectionSettings.TrustServerCertificate
+        };
+
+        if (ConnectionSettings.AuthenticationMode == SqlServerAuthenticationMode.WindowsIntegrated)
+        {
+            builder.IntegratedSecurity = true;
+        }
+        else
+        {
+            builder.UserID = ConnectionSettings.User;
+            builder.Password = ConnectionSettings.Password;
+        }
+
+        return builder.ConnectionString;
     }
 }

--- a/DataDeveloper.Data/Services/DatabaseProviderBase.cs
+++ b/DataDeveloper.Data/Services/DatabaseProviderBase.cs
@@ -1,6 +1,5 @@
 using System.Data;
 using System.Data.Common;
-using System.Text;
 using DataDeveloper.Data.Interfaces;
 using DataDeveloper.Data.Models;
 
@@ -16,6 +15,7 @@ public abstract class DatabaseProviderBase<TConnectionSettings> : IDatabaseProvi
 
     public TConnectionSettings ConnectionSettings { get; }
     public abstract DbConnection GetConnection();
+    public virtual IReadOnlyList<string> GetAvailableDatabaseNames() => Array.Empty<string>();
     public abstract string GetTableStatement();
     public abstract string GetViewStatement();
     public abstract string GetColumnStatement();

--- a/DataDeveloper.Data/Services/DatabaseProviderFactoryService.cs
+++ b/DataDeveloper.Data/Services/DatabaseProviderFactoryService.cs
@@ -10,7 +10,7 @@ namespace DataDeveloper.Data.Services;
 
 public class DatabaseProviderFactoryService
 {
-    public IDatabaseProvider GetDatabaseProvider(IConnectionSettings connectionSettings)
+    public virtual IDatabaseProvider GetDatabaseProvider(IConnectionSettings connectionSettings)
     {
         return connectionSettings.DatabaseType switch
         {

--- a/DataDeveloper.Data/Services/SchemaExplorer.cs
+++ b/DataDeveloper.Data/Services/SchemaExplorer.cs
@@ -23,7 +23,7 @@ public class SchemaExplorer : ISchemaExplorer
         var connection = RootConnections.FirstOrDefault();
         if (connection is null)
         {
-            connection = new SchemaNode(NodeType.Connection, ConnectionSettings.Name, isFolder: true, parent: null)
+            connection = new SchemaNode(NodeType.Connection, BuildConnectionNodeName(), isFolder: true, parent: null)
             {
                 IsExpanded = true
             };
@@ -264,6 +264,23 @@ public class SchemaExplorer : ISchemaExplorer
     {
         var connection = RootConnections.FirstOrDefault();
         return connection?.Children.FirstOrDefault(child => child.NodeType == folderType);
+    }
+
+    private string BuildConnectionNodeName()
+    {
+        var databaseName = ConnectionSettings switch
+        {
+            DataDeveloper.Data.Providers.SqlServer.SqlServerConnectionSettings sqlServer => sqlServer.Database,
+            DataDeveloper.Data.Providers.MySql.MySqlConnectionSettings mySql => mySql.Database,
+            DataDeveloper.Data.Providers.PostgresSql.PostgresConnectionSettings postgres => postgres.Database,
+            DataDeveloper.Data.Providers.Oracle.OracleConnectionSettings oracle => oracle.Database,
+            DataDeveloper.Data.Providers.SqLite.SqLiteConnectionSettings sqLite => sqLite.Database,
+            _ => string.Empty
+        };
+
+        return string.IsNullOrWhiteSpace(databaseName)
+            ? ConnectionSettings.Name
+            : $"{ConnectionSettings.Name} ({databaseName})";
     }
 
     private async Task SyncObjectFolderAsync(SchemaNode folder, IEnumerable<string> objectNames, NodeType nodeType, Func<string, string?>? detailsFactory)

--- a/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
+++ b/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 using System.Reactive.Threading.Tasks;
 using DataDeveloper.Data.Enums;
+using DataDeveloper.Data.Interfaces;
 using DataDeveloper.Data.Models;
 using DataDeveloper.Data.Providers.MySql;
 using DataDeveloper.Data.Providers.Oracle;
@@ -23,6 +25,7 @@ public class ConnectionSelectorViewModelTests
     {
         private readonly List<ConnectionSettings> _connections;
         public int DeleteCallCount { get; private set; }
+        public ConnectionSettings? LastSavedConnection { get; private set; }
 
         public FakeConnectionSettingsRepository(IEnumerable<ConnectionSettings>? connections = null)
         {
@@ -39,6 +42,7 @@ public class ConnectionSelectorViewModelTests
 
         public void Save(ConnectionSettings connectionSettings)
         {
+            LastSavedConnection = connectionSettings;
         }
 
         public void Delete(ConnectionSettings connectionSettings)
@@ -84,6 +88,38 @@ public class ConnectionSelectorViewModelTests
         public Task<string?> ShowOpenDatabaseFileAsync(string? title = null) => Task.FromResult(OpenDatabaseFileResult);
 
         public Task<string?> ShowCreateDatabaseFileAsync(string? suggestedName = null, string? title = null) => Task.FromResult(CreateDatabaseFileResult);
+    }
+
+    private sealed class FakeDatabaseProvider : IDatabaseProvider
+    {
+        private readonly IReadOnlyList<string> _databaseNames;
+
+        public FakeDatabaseProvider(IReadOnlyList<string> databaseNames)
+        {
+            _databaseNames = databaseNames;
+        }
+
+        public DbConnection GetConnection() => throw new NotSupportedException();
+        public TestConnectionResult TestConnection() => new(true, "ok");
+        public IReadOnlyList<string> GetAvailableDatabaseNames() => _databaseNames;
+        public string GetTableStatement() => string.Empty;
+        public string GetViewStatement() => string.Empty;
+        public string GetColumnStatement() => string.Empty;
+        public string GetProcedureStatement() => string.Empty;
+        public string GetFunctionStatement() => string.Empty;
+        public string GetRoutineParameterStatement() => string.Empty;
+    }
+
+    private sealed class FakeDatabaseProviderFactoryService : DatabaseProviderFactoryService
+    {
+        private readonly IDatabaseProvider _provider;
+
+        public FakeDatabaseProviderFactoryService(IDatabaseProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public override IDatabaseProvider GetDatabaseProvider(IConnectionSettings connectionSettings) => _provider;
     }
 
     [Fact]
@@ -181,6 +217,125 @@ public class ConnectionSelectorViewModelTests
         Assert.Equal(DatabaseType.SqLite, connection.DatabaseType);
         Assert.Equal(string.Empty, connection.Database);
     }
+
+    [Fact]
+    public void SqlServer_UsesCredentialsForSelectedConnection_DependsOnAuthenticationMode()
+    {
+        var connection = new SqlServerConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            DatabaseType = DatabaseType.SqlServer,
+            Name = "SQL Server",
+            Server = @"(localdb)\MSSQLLocalDB",
+            Database = "master",
+            AuthenticationMode = SqlServerAuthenticationMode.SqlLogin
+        };
+        var viewModel = new ConnectionSelectorViewModel(
+            new FakeConnectionSettingsRepository([connection]),
+            new DatabaseProviderFactoryService(),
+            new InMemorySecretStore(),
+            new FakeDialogService())
+        {
+            SelectedConnection = connection
+        };
+
+        Assert.True(viewModel.UsesSqlServerAuthenticationMode);
+        Assert.True(viewModel.UsesCredentialsForSelectedConnection);
+
+        viewModel.SelectedSqlServerAuthenticationOption = viewModel.SqlServerAuthenticationModes
+            .Single(option => option.Value == SqlServerAuthenticationMode.WindowsIntegrated);
+
+        Assert.False(viewModel.UsesCredentialsForSelectedConnection);
+    }
+
+    [Fact]
+    public async Task ApplyCommand_ClearsCredentials_ForSqlServerWindowsAuthentication()
+    {
+        var repository = new FakeConnectionSettingsRepository();
+        var connection = new SqlServerConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            DatabaseType = DatabaseType.SqlServer,
+            Name = "SQL Server",
+            Server = @"(localdb)\MSSQLLocalDB",
+            Database = "master",
+            AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
+            User = "sa",
+            Password = "secret",
+            CredentialId = Guid.NewGuid()
+        };
+        var viewModel = new ConnectionSelectorViewModel(
+            repository,
+            new DatabaseProviderFactoryService(),
+            new InMemorySecretStore(),
+            new FakeDialogService())
+        {
+            SelectedConnection = connection,
+            IsEditing = true
+        };
+
+        await viewModel.ApplyCommand.Execute(null!).ToTask();
+
+        var saved = Assert.IsType<SqlServerConnectionSettings>(repository.LastSavedConnection);
+        Assert.Equal(string.Empty, saved.User);
+        Assert.Equal(string.Empty, saved.Password);
+        Assert.True(saved.IsPasswordLoaded);
+        Assert.Equal(string.Empty, saved.LoadedPasswordSnapshot);
+    }
+
+    [Fact]
+    public async Task RefreshDatabaseNamesCommand_LoadsAvailableDatabases_AndPreservesCurrentValue()
+    {
+        var connection = new SqlServerConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            DatabaseType = DatabaseType.SqlServer,
+            Name = "SQL Server",
+            Server = @"(localdb)\MSSQLLocalDB",
+            Database = "custom_db",
+            AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated
+        };
+        var provider = new FakeDatabaseProvider(["master", "tempdb", "model"]);
+        var viewModel = new ConnectionSelectorViewModel(
+            new FakeConnectionSettingsRepository([connection]),
+            new FakeDatabaseProviderFactoryService(provider),
+            new InMemorySecretStore(),
+            new FakeDialogService())
+        {
+            SelectedConnection = connection,
+            IsEditing = true
+        };
+
+        await viewModel.RefreshDatabaseNamesCommand.Execute().ToTask();
+
+        Assert.True(viewModel.CanRefreshDatabaseNames);
+        Assert.Equal(["custom_db", "master", "model", "tempdb"], viewModel.AvailableDatabaseNames);
+    }
+
+    [Fact]
+    public void SelectingSqLiteConnection_DisablesDatabaseRefresh()
+    {
+        var connection = new SqLiteConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            DatabaseType = DatabaseType.SqLite,
+            Name = "SQLite",
+            Database = "/tmp/app.db"
+        };
+        var viewModel = new ConnectionSelectorViewModel(
+            new FakeConnectionSettingsRepository([connection]),
+            new DatabaseProviderFactoryService(),
+            new InMemorySecretStore(),
+            new FakeDialogService())
+        {
+            SelectedConnection = connection
+        };
+
+        Assert.False(viewModel.CanRefreshDatabaseNames);
+        Assert.Single(viewModel.AvailableDatabaseNames);
+        Assert.Equal("/tmp/app.db", viewModel.AvailableDatabaseNames[0]);
+    }
+
 
     [Fact]
     public async Task SelectSqLiteFileCommand_UpdatesDatabasePath()

--- a/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
+++ b/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
@@ -29,6 +29,7 @@ public class ConnectionSettingsConverterTests
                               "DatabaseType":"SqlServer",
                               "Server":"localhost",
                               "Database":"master",
+                              "AuthenticationMode":"WindowsIntegrated",
                               "User":"sa",
                               "Password":"pwd",
                               "Encrypt":true,
@@ -41,6 +42,7 @@ public class ConnectionSettingsConverterTests
         var typed = Assert.IsType<SqlServerConnectionSettings>(connection);
         Assert.Equal(DatabaseType.SqlServer, typed.DatabaseType);
         Assert.Equal("localhost", typed.Server);
+        Assert.Equal(SqlServerAuthenticationMode.WindowsIntegrated, typed.AuthenticationMode);
     }
 
     [Fact]
@@ -145,6 +147,7 @@ public class ConnectionSettingsConverterTests
             DatabaseType = DatabaseType.SqlServer,
             Server = "localhost",
             Database = "master",
+            AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
             User = "sa",
             Password = "pwd",
             Encrypt = true,
@@ -157,6 +160,7 @@ public class ConnectionSettingsConverterTests
         var typed = Assert.IsType<SqlServerConnectionSettings>(deserialized);
         Assert.Equal("localhost", typed.Server);
         Assert.Equal(DatabaseType.SqlServer, typed.DatabaseType);
+        Assert.Equal(SqlServerAuthenticationMode.WindowsIntegrated, typed.AuthenticationMode);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/Providers/SqlServerDatabaseProviderTests.cs
+++ b/DataDeveloper.Tests/Providers/SqlServerDatabaseProviderTests.cs
@@ -13,6 +13,7 @@ public class SqlServerDatabaseProviderTests
         {
             Server = "localhost",
             Database = "master",
+            AuthenticationMode = SqlServerAuthenticationMode.SqlLogin,
             User = "sa",
             Password = "pwd",
             Encrypt = true,
@@ -27,6 +28,36 @@ public class SqlServerDatabaseProviderTests
         Assert.Equal("master", builder.InitialCatalog);
         Assert.True(builder.Encrypt);
         Assert.False(builder.TrustServerCertificate);
+        Assert.False(builder.IntegratedSecurity);
+        Assert.Equal("sa", builder.UserID);
+        Assert.Equal("pwd", builder.Password);
+    }
+
+    [Fact]
+    public void GetConnection_UsesIntegratedSecurity_ForWindowsAuthentication()
+    {
+        var provider = new SqlServerDatabaseProvider(new SqlServerConnectionSettings
+        {
+            Server = @"(localdb)\MSSQLLocalDB",
+            Database = "master",
+            AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
+            User = "sa",
+            Password = "pwd",
+            Encrypt = true,
+            TrustServerCertificate = true
+        });
+
+        var connection = provider.GetConnection();
+
+        var sqlConnection = Assert.IsType<SqlConnection>(connection);
+        var builder = new SqlConnectionStringBuilder(sqlConnection.ConnectionString);
+        Assert.Equal(@"(localdb)\MSSQLLocalDB", builder.DataSource);
+        Assert.Equal("master", builder.InitialCatalog);
+        Assert.True(builder.IntegratedSecurity);
+        Assert.True(builder.Encrypt);
+        Assert.True(builder.TrustServerCertificate);
+        Assert.True(string.IsNullOrEmpty(builder.UserID));
+        Assert.True(string.IsNullOrEmpty(builder.Password));
     }
 
     [Fact]

--- a/DataDeveloper.Tests/SchemaExplorerTests.cs
+++ b/DataDeveloper.Tests/SchemaExplorerTests.cs
@@ -1,0 +1,52 @@
+using System.Data.Common;
+using DataDeveloper.Data.Enums;
+using DataDeveloper.Data.Interfaces;
+using DataDeveloper.Data.Models;
+using DataDeveloper.Data.Providers.SqlServer;
+using DataDeveloper.Data.Services;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace DataDeveloper.Tests;
+
+public class SchemaExplorerTests
+{
+    private sealed class FakeDatabaseProvider : IDatabaseProvider
+    {
+        public DbConnection GetConnection()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            connection.Open();
+            return connection;
+        }
+
+        public TestConnectionResult TestConnection() => new(true, "ok");
+        public IReadOnlyList<string> GetAvailableDatabaseNames() => [];
+        public string GetTableStatement() => "select cast(null as text) as Name where 1 = 0";
+        public string GetViewStatement() => "select cast(null as text) as Name where 1 = 0";
+        public string GetColumnStatement() => "select cast(null as text) as Name where 1 = 0";
+        public string GetProcedureStatement() => "select cast(null as text) as Name, cast(null as text) as SpecificName where 1 = 0";
+        public string GetFunctionStatement() => "select cast(null as text) as Name, cast(null as text) as SpecificName, cast(null as text) as DataType where 1 = 0";
+        public string GetRoutineParameterStatement() => "select cast(null as text) as Name where 1 = 0";
+    }
+
+    [Fact]
+    public async Task InitializeSchemaNode_UsesConnectionNameWithDatabase_ForRootNode()
+    {
+        var connection = new SqlServerConnectionSettings
+        {
+            DatabaseType = DatabaseType.SqlServer,
+            Name = "Oreons-Backoffice",
+            Server = "localhost",
+            Database = "NXGenMarketplace_Backoffice_Development"
+        };
+        var explorer = new SchemaExplorer(new FakeDatabaseProvider(), connection);
+
+        await explorer.InitializeSchemaNode();
+
+        var root = Assert.Single(explorer.RootConnections);
+        Assert.Equal(
+            "Oreons-Backoffice (NXGenMarketplace_Backoffice_Development)",
+            root.Name);
+    }
+}

--- a/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
+++ b/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
@@ -70,6 +70,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
             DatabaseType = DatabaseType.SqlServer,
             Server = "sql.local",
             Database = "master",
+            AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
             User = "sa",
             Password = "secret",
             Encrypt = true,
@@ -99,6 +100,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(sqlServer.CredentialId, loadedSqlServer.CredentialId);
         Assert.Equal(sqlServer.Server, loadedSqlServer.Server);
         Assert.Equal(sqlServer.Database, loadedSqlServer.Database);
+        Assert.Equal(sqlServer.AuthenticationMode, loadedSqlServer.AuthenticationMode);
         repository.LoadPassword(loadedSqlServer);
         Assert.Equal(sqlServer.Password, loadedSqlServer.Password);
 
@@ -283,6 +285,74 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal("first-secret", reloadedFirst.Password);
         Assert.Equal("second-secret", reloadedSecond.Password);
         Assert.Equal("Second updated", reloadedSecond.Name);
+    }
+
+    [Fact]
+    public void LoadAll_DefaultsSqlServerAuthenticationMode_WhenColumnIsMissing()
+    {
+        var databasePath = Path.Combine(_tempDirectory, "legacy.db");
+        using (var connection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={databasePath}"))
+        {
+            connection.Open();
+            using var createCommand = connection.CreateCommand();
+            createCommand.CommandText = """
+                                        create table app_connection
+                                        (
+                                            id text not null primary key,
+                                            credential_id text null,
+                                            name text not null,
+                                            database_type integer not null,
+                                            user_name text not null,
+                                            encrypt integer not null,
+                                            trust_server_certificate integer not null,
+                                            allow_blank_password integer not null,
+                                            server text not null,
+                                            database_name text not null,
+                                            port integer null,
+                                            created_at text not null,
+                                            updated_at text not null
+                                        );
+                                        insert into app_connection
+                                        (
+                                            id,
+                                            credential_id,
+                                            name,
+                                            database_type,
+                                            user_name,
+                                            encrypt,
+                                            trust_server_certificate,
+                                            allow_blank_password,
+                                            server,
+                                            database_name,
+                                            port,
+                                            created_at,
+                                            updated_at
+                                        )
+                                        values
+                                        (
+                                            '11111111-1111-1111-1111-111111111111',
+                                            null,
+                                            'Legacy SQL',
+                                            0,
+                                            'sa',
+                                            1,
+                                            0,
+                                            0,
+                                            'sql.local',
+                                            'master',
+                                            null,
+                                            '2026-04-08T00:00:00.0000000Z',
+                                            '2026-04-08T00:00:00.0000000Z'
+                                        );
+                                        """;
+            createCommand.ExecuteNonQuery();
+        }
+
+        var repository = new SqliteConnectionSettingsRepository(databasePath, new InMemorySecretStore());
+
+        var loaded = Assert.IsType<SqlServerConnectionSettings>(Assert.Single(repository.LoadAll()));
+
+        Assert.Equal(SqlServerAuthenticationMode.SqlLogin, loaded.AuthenticationMode);
     }
 
     [Fact]

--- a/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
+++ b/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
@@ -47,6 +47,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   credential_id,
                                   name,
                                   database_type,
+                                  sql_server_authentication_mode,
                                   user_name,
                                   encrypt,
                                   trust_server_certificate,
@@ -79,6 +80,9 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             switch (connectionSettings)
             {
                 case SqlServerConnectionSettings sqlServer:
+                    sqlServer.AuthenticationMode = reader.IsDBNull(reader.GetOrdinal("sql_server_authentication_mode"))
+                        ? SqlServerAuthenticationMode.SqlLogin
+                        : (SqlServerAuthenticationMode)reader.GetInt32(reader.GetOrdinal("sql_server_authentication_mode"));
                     sqlServer.Server = reader.GetString(reader.GetOrdinal("server"));
                     sqlServer.Database = reader.GetString(reader.GetOrdinal("database_name"));
                     break;
@@ -159,6 +163,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             else if (item.CredentialId is not null)
             {
                 secretStore.DeleteAsync(item.CredentialId.Value.ToString()).GetAwaiter().GetResult();
+                item.CredentialId = null;
             }
 
             using var command = connection.CreateCommand();
@@ -170,6 +175,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                       credential_id,
                                       name,
                                       database_type,
+                                      sql_server_authentication_mode,
                                       user_name,
                                       encrypt,
                                       trust_server_certificate,
@@ -186,6 +192,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                       $credentialId,
                                       $name,
                                       $databaseType,
+                                      $sqlServerAuthenticationMode,
                                       $userName,
                                       $encrypt,
                                       $trustServerCertificate,
@@ -203,6 +210,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             command.Parameters.AddWithValue("$credentialId", item.CredentialId?.ToString() ?? (object)DBNull.Value);
             command.Parameters.AddWithValue("$name", item.Name);
             command.Parameters.AddWithValue("$databaseType", (int)item.DatabaseType);
+            command.Parameters.AddWithValue("$sqlServerAuthenticationMode", GetSqlServerAuthenticationMode(item));
             command.Parameters.AddWithValue("$userName", item.User);
             command.Parameters.AddWithValue("$encrypt", item.Encrypt ? 1 : 0);
             command.Parameters.AddWithValue("$trustServerCertificate", item.TrustServerCertificate ? 1 : 0);
@@ -242,6 +250,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         else if (connectionSettings.CredentialId is not null && connectionSettings.IsPasswordLoaded)
         {
             _secretStore.DeleteAsync(connectionSettings.CredentialId.Value.ToString()).GetAwaiter().GetResult();
+            connectionSettings.CredentialId = null;
             connectionSettings.LoadedPasswordSnapshot = string.Empty;
         }
 
@@ -254,6 +263,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   credential_id,
                                   name,
                                   database_type,
+                                  sql_server_authentication_mode,
                                   user_name,
                                   encrypt,
                                   trust_server_certificate,
@@ -270,6 +280,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   $credentialId,
                                   $name,
                                   $databaseType,
+                                  $sqlServerAuthenticationMode,
                                   $userName,
                                   $encrypt,
                                   $trustServerCertificate,
@@ -284,6 +295,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   credential_id = excluded.credential_id,
                                   name = excluded.name,
                                   database_type = excluded.database_type,
+                                  sql_server_authentication_mode = excluded.sql_server_authentication_mode,
                                   user_name = excluded.user_name,
                                   encrypt = excluded.encrypt,
                                   trust_server_certificate = excluded.trust_server_certificate,
@@ -301,6 +313,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         command.Parameters.AddWithValue("$credentialId", connectionSettings.CredentialId?.ToString() ?? (object)DBNull.Value);
         command.Parameters.AddWithValue("$name", connectionSettings.Name);
         command.Parameters.AddWithValue("$databaseType", (int)connectionSettings.DatabaseType);
+        command.Parameters.AddWithValue("$sqlServerAuthenticationMode", GetSqlServerAuthenticationMode(connectionSettings));
         command.Parameters.AddWithValue("$userName", connectionSettings.User);
         command.Parameters.AddWithValue("$encrypt", connectionSettings.Encrypt ? 1 : 0);
         command.Parameters.AddWithValue("$trustServerCertificate", connectionSettings.TrustServerCertificate ? 1 : 0);
@@ -347,6 +360,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   credential_id text null,
                                   name text not null,
                                   database_type integer not null,
+                                  sql_server_authentication_mode integer not null default 0,
                                   user_name text not null,
                                   encrypt integer not null,
                                   trust_server_certificate integer not null,
@@ -359,6 +373,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                               );
                               """;
         command.ExecuteNonQuery();
+        EnsureColumnExists(connection, "sql_server_authentication_mode", "integer not null default 0");
 
         _isInitialized = true;
     }
@@ -430,4 +445,26 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             MySqlConnectionSettings mySql => (long)mySql.Port,
             _ => DBNull.Value
         };
+
+    private static int GetSqlServerAuthenticationMode(ConnectionSettings connectionSettings) =>
+        connectionSettings is SqlServerConnectionSettings sqlServer
+            ? (int)sqlServer.AuthenticationMode
+            : (int)SqlServerAuthenticationMode.SqlLogin;
+
+    private static void EnsureColumnExists(SqliteConnection connection, string columnName, string columnDefinition)
+    {
+        using var pragmaCommand = connection.CreateCommand();
+        pragmaCommand.CommandText = "pragma table_info(app_connection);";
+        using var reader = pragmaCommand.ExecuteReader();
+
+        while (reader.Read())
+        {
+            if (string.Equals(reader.GetString(reader.GetOrdinal("name")), columnName, StringComparison.OrdinalIgnoreCase))
+                return;
+        }
+
+        using var alterCommand = connection.CreateCommand();
+        alterCommand.CommandText = $"alter table app_connection add column {columnName} {columnDefinition};";
+        alterCommand.ExecuteNonQuery();
+    }
 }

--- a/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
+++ b/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
@@ -37,6 +37,18 @@ public sealed class ConnectionTypeFilterOption
     public bool HasDatabaseType => DatabaseType is not null;
 }
 
+public sealed class SqlServerAuthenticationOption
+{
+    public SqlServerAuthenticationOption(string displayName, SqlServerAuthenticationMode value)
+    {
+        DisplayName = displayName;
+        Value = value;
+    }
+
+    public string DisplayName { get; }
+    public SqlServerAuthenticationMode Value { get; }
+}
+
 public class ConnectionSelectorViewModel : ViewModelBase
 {
     private readonly IConnectionSettingsRepository _connectionSettingsRepository;
@@ -44,6 +56,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
     private readonly ISecretStore _secretStore;
     private readonly IDialogService _dialogService;
     private readonly ObservableCollection<ConnectionSettings> _allConnections = new();
+    private readonly ObservableCollection<string> _availableDatabaseNames = new();
 
     public ConnectionSelectorViewModel(IConnectionSettingsRepository connectionSettingsRepository, DatabaseProviderFactoryService databaseProviderFactoryService, ISecretStore secretStore, IDialogService dialogService)
     {
@@ -60,6 +73,12 @@ public class ConnectionSelectorViewModel : ViewModelBase
             new ConnectionTypeFilterOption("MySQL", DatabaseType.MySql),
             new ConnectionTypeFilterOption("SQLite", DatabaseType.SqLite)
         ];
+        SqlServerAuthenticationModes =
+        [
+            new SqlServerAuthenticationOption("SQL Server Authentication", SqlServerAuthenticationMode.SqlLogin),
+            new SqlServerAuthenticationOption("Windows Authentication", SqlServerAuthenticationMode.WindowsIntegrated)
+        ];
+        AvailableDatabaseNames = new ReadOnlyObservableCollection<string>(_availableDatabaseNames);
         LoadConnections();
         SelectedConnectionFilter = AvailableConnectionFilters[0];
         
@@ -111,6 +130,28 @@ public class ConnectionSelectorViewModel : ViewModelBase
             CreateSqLiteFileAsync,
             this.WhenAnyValue(x => x.SelectedConnection, x => x.IsSqLiteConnectionSelected, x => x.IsEditing,
                 (connection, isSqLite, isEditing) => connection is not null && isSqLite && isEditing));
+        RefreshDatabaseNamesCommand = ReactiveCommand.CreateFromTask(
+            RefreshDatabaseNamesAsync,
+            this.WhenAnyValue(x => x.SelectedConnection, x => x.CanRefreshDatabaseNames, x => x.IsEditing,
+                (connection, canRefresh, isEditing) => connection is not null && canRefresh && isEditing));
+
+        this.WhenAnyValue(x => x.SelectedConnection)
+            .Select(connection => connection is SqlServerConnectionSettings sqlServer
+                ? sqlServer.WhenAnyValue(x => x.AuthenticationMode)
+                : Observable.Return(SqlServerAuthenticationMode.SqlLogin))
+            .Switch()
+            .Subscribe(_ =>
+            {
+                this.RaisePropertyChanged(nameof(UsesCredentialsForSelectedConnection));
+                this.RaisePropertyChanged(nameof(SelectedSqlServerAuthenticationOption));
+            });
+
+        this.WhenAnyValue(x => x.SelectedConnection)
+            .Subscribe(connection =>
+            {
+                LoadAvailableDatabaseNames(GetCurrentDatabaseName(connection));
+                this.RaisePropertyChanged(nameof(CanRefreshDatabaseNames));
+            });
     }
 
     private async Task DuplicateConnectionAsync()
@@ -188,7 +229,9 @@ public class ConnectionSelectorViewModel : ViewModelBase
     }
 
     public ObservableCollection<ConnectionSettings> Connections { get; private set; } = new();
+    public ReadOnlyObservableCollection<string> AvailableDatabaseNames { get; }
     public IReadOnlyList<ConnectionTypeFilterOption> AvailableConnectionFilters { get; }
+    public IReadOnlyList<SqlServerAuthenticationOption> SqlServerAuthenticationModes { get; }
 
     private ConnectionSettings? _selectedConnection;
     public ConnectionSettings? SelectedConnection
@@ -207,6 +250,9 @@ public class ConnectionSelectorViewModel : ViewModelBase
             this.RaisePropertyChanged(nameof(UsesCredentials));
             this.RaisePropertyChanged(nameof(ShowsSecurityOptions));
             this.RaisePropertyChanged(nameof(DatabaseLabel));
+            this.RaisePropertyChanged(nameof(UsesSqlServerAuthenticationMode));
+            this.RaisePropertyChanged(nameof(UsesCredentialsForSelectedConnection));
+            this.RaisePropertyChanged(nameof(SelectedSqlServerAuthenticationOption));
         }
     }
 
@@ -239,7 +285,16 @@ public class ConnectionSelectorViewModel : ViewModelBase
         SelectedConnection?.DatabaseType is DatabaseType.MySql or DatabaseType.PostgresSql or DatabaseType.Oracle;
     public bool IsServerConnectionSelected => SelectedConnection?.DatabaseType != DatabaseType.SqLite;
     public bool UsesCredentials => SelectedConnection?.DatabaseType != DatabaseType.SqLite;
+    public bool UsesSqlServerAuthenticationMode => SelectedConnection?.DatabaseType == DatabaseType.SqlServer;
+    public bool UsesCredentialsForSelectedConnection =>
+        SelectedConnection switch
+        {
+            SqlServerConnectionSettings sqlServer => sqlServer.AuthenticationMode == SqlServerAuthenticationMode.SqlLogin,
+            null => false,
+            _ => UsesCredentials
+        };
     public bool ShowsSecurityOptions => SelectedConnection?.DatabaseType is DatabaseType.SqlServer or DatabaseType.PostgresSql or DatabaseType.MySql;
+    public bool CanRefreshDatabaseNames => SelectedConnection?.DatabaseType is DatabaseType.SqlServer or DatabaseType.MySql or DatabaseType.PostgresSql;
     public string DatabaseLabel => SelectedConnection?.DatabaseType switch
     {
         DatabaseType.Oracle => "Service Name",
@@ -250,6 +305,19 @@ public class ConnectionSelectorViewModel : ViewModelBase
     public string SecureStorageWarningMessage => _secretStore.UnavailableReason ?? string.Empty;
     public bool CanAddConnection => SelectedConnectionFilter?.DatabaseType is not null;
     public bool ShowFilterSelectionHint => !CanAddConnection;
+    public SqlServerAuthenticationOption? SelectedSqlServerAuthenticationOption
+    {
+        get => SelectedConnection is SqlServerConnectionSettings sqlServer
+            ? SqlServerAuthenticationModes.FirstOrDefault(option => option.Value == sqlServer.AuthenticationMode)
+            : null;
+        set
+        {
+            if (SelectedConnection is not SqlServerConnectionSettings sqlServer || value is null)
+                return;
+
+            sqlServer.AuthenticationMode = value.Value;
+        }
+    }
     
     public SqlConnectionInfo? ConnectionInfo { get; private set; }
 
@@ -263,6 +331,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
     public ReactiveCommand<Unit, Unit> DuplicateConnectionCommand { get; }
     public ReactiveCommand<Unit, Unit> SelectSqLiteFileCommand { get; }
     public ReactiveCommand<Unit, Unit> CreateSqLiteFileCommand { get; }
+    public ReactiveCommand<Unit, Unit> RefreshDatabaseNamesCommand { get; }
 
     private async Task OkAsync(StyledElement element)
     {
@@ -288,6 +357,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
             return false;
         }
 
+        SanitizeAuthenticationSensitiveFields(SelectedConnection);
         await Task.Run(() => _connectionSettingsRepository.LoadPassword(SelectedConnection));
 
         if (!_secretStore.IsAvailable && !string.IsNullOrWhiteSpace(SelectedConnection.Password))
@@ -422,6 +492,18 @@ public class ConnectionSelectorViewModel : ViewModelBase
         };
     }
 
+    private static void SanitizeAuthenticationSensitiveFields(ConnectionSettings connectionSettings)
+    {
+        if (connectionSettings is not SqlServerConnectionSettings sqlServer ||
+            sqlServer.AuthenticationMode != SqlServerAuthenticationMode.WindowsIntegrated)
+            return;
+
+        sqlServer.User = string.Empty;
+        sqlServer.Password = string.Empty;
+        sqlServer.IsPasswordLoaded = true;
+        sqlServer.LoadedPasswordSnapshot = string.Empty;
+    }
+
     private async Task SelectSqLiteFileAsync()
     {
         if (SelectedConnection is not SqLiteConnectionSettings sqLiteConnection)
@@ -444,4 +526,58 @@ public class ConnectionSelectorViewModel : ViewModelBase
         if (!string.IsNullOrWhiteSpace(createdPath))
             sqLiteConnection.Database = createdPath;
     }
+
+    private async Task RefreshDatabaseNamesAsync()
+    {
+        if (SelectedConnection is null)
+            return;
+
+        try
+        {
+            await Task.Run(() => _connectionSettingsRepository.LoadPassword(SelectedConnection));
+            SanitizeAuthenticationSensitiveFields(SelectedConnection);
+            var databaseProvider = _databaseProviderFactoryService.GetDatabaseProvider(SelectedConnection);
+            var names = await Task.Run(() => databaseProvider.GetAvailableDatabaseNames());
+            LoadAvailableDatabaseNames(GetCurrentDatabaseName(SelectedConnection), names);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowDialogAsync(
+                $"Could not load databases\r\n\r\n{ex.Message}",
+                "Connection...",
+                DialogButtons.Ok,
+                DialogIcon.Error);
+        }
+    }
+
+    private void LoadAvailableDatabaseNames(string? currentDatabase, IEnumerable<string>? names = null)
+    {
+        _availableDatabaseNames.Clear();
+
+        var values = (names ?? Enumerable.Empty<string>())
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var name in values)
+            _availableDatabaseNames.Add(name);
+
+        if (!string.IsNullOrWhiteSpace(currentDatabase) &&
+            !_availableDatabaseNames.Contains(currentDatabase, StringComparer.OrdinalIgnoreCase))
+        {
+            _availableDatabaseNames.Insert(0, currentDatabase);
+        }
+    }
+
+    private static string? GetCurrentDatabaseName(ConnectionSettings? connectionSettings) =>
+        connectionSettings switch
+        {
+            SqlServerConnectionSettings sqlServer => sqlServer.Database,
+            MySqlConnectionSettings mySql => mySql.Database,
+            PostgresConnectionSettings postgres => postgres.Database,
+            OracleConnectionSettings oracle => oracle.Database,
+            SqLiteConnectionSettings sqLite => sqLite.Database,
+            _ => null
+        };
 }

--- a/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
+++ b/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
@@ -119,10 +119,35 @@
                     IsVisible="{Binding IsServerConnectionSelected}" />
 
                 <TextBlock Text="{Binding DatabaseLabel}" />
-                <TextBox 
-                    Text="{Binding SelectedConnection.Database, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    IsEnabled="{Binding IsEditing}"
-                    IsReadOnly="{Binding !IsEditing}" />
+                <Grid ColumnDefinitions="*,Auto"
+                      ColumnSpacing="8"
+                      HorizontalAlignment="Stretch">
+                    <ComboBox Grid.Column="0"
+                              ItemsSource="{Binding AvailableDatabaseNames}"
+                              Text="{Binding SelectedConnection.Database, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                              IsEditable="True"
+                              HorizontalAlignment="Stretch"
+                              IsEnabled="{Binding IsEditing}" />
+                    <Button Grid.Column="1"
+                            Content="..."
+                            Command="{Binding RefreshDatabaseNamesCommand}"
+                            IsVisible="{Binding CanRefreshDatabaseNames}"
+                            IsEnabled="{Binding IsEditing}" />
+                </Grid>
+
+                <Grid RowDefinitions="Auto,Auto"
+                      IsVisible="{Binding UsesSqlServerAuthenticationMode}">
+                    <TextBlock Grid.Row="0" Text="Authentication" />
+                    <ComboBox Grid.Row="1"
+                              ItemsSource="{Binding SqlServerAuthenticationModes}"
+                              SelectedItem="{Binding SelectedSqlServerAuthenticationOption, Mode=TwoWay}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayName}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </Grid>
 
                 <StackPanel Orientation="Horizontal"
                             Spacing="8"
@@ -143,7 +168,7 @@
                 </Grid>
 
                 <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,*" ColumnSpacing="10" RowSpacing="8"
-                      IsVisible="{Binding UsesCredentials}">
+                      IsVisible="{Binding UsesCredentialsForSelectedConnection}">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Username" />
                     <TextBox Grid.Row="1" Grid.Column="0" 
                              Text="{Binding SelectedConnection.User, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -172,6 +197,12 @@
                 </Grid>
 
                 <TextBlock Text="Use 'Trust server certificate' only when the SQL Server certificate is not trusted on this machine."
+                           FontSize="11"
+                           Foreground="DarkGoldenrod"
+                           TextWrapping="Wrap"
+                           IsVisible="{Binding IsSqlServerConnectionSelected}" />
+
+                <TextBlock Text="For LocalDB, use SQL Server with Windows Authentication and a server such as (localdb)\MSSQLLocalDB."
                            FontSize="11"
                            Foreground="DarkGoldenrod"
                            TextWrapping="Wrap"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ DataDeveloper currently supports SQL Server, Oracle, MySQL, PostgreSQL, and SQLi
 ## Features
 
 - Manage saved database connections for SQL Server, Oracle, MySQL, PostgreSQL, and SQLite
+- Connect to SQL Server with SQL login or Windows Authentication, including LocalDB instances such as `(localdb)\MSSQLLocalDB`
+- Load visible database names for SQL Server, MySQL, and PostgreSQL directly from the connection dialog while still allowing manual entry
 - Configure Oracle connections with server, port, service name, and credentials, or point SQLite connections to a local database file
 - Store saved connections in a local app-state database
 - Store connection credentials using the operating system secure storage


### PR DESCRIPTION
## Summary
- add SQL Server Windows Authentication support, including LocalDB scenarios
- add an editable database picker with refresh support for SQL Server, MySQL, and PostgreSQL
- show the selected database in the root connection node of the schema explorer tree

## Testing
- dotnet test DataDeveloper.Tests/DataDeveloper.Tests.csproj -m:1 --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false -nodeReuse:false
- manual validation on Windows VM with SQL Server LocalDB and Windows Authentication