### PR TITLE
Improve editor execution flow and result loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,13 +15,13 @@
 - When running `dotnet build`, `dotnet test`, or other validation commands for `DataDeveloper`, run them sequentially, not in parallel, to avoid wasting time on reruns caused by concurrent build/test interference.
 
 ## Provider compatibility
-- Starting from the `feature/mysql` branch, every new feature must support both SQL Server and MySQL.
-- Do not introduce new SQL Server-only behavior without handling the MySQL equivalent, or without explicitly documenting and approving the limitation.
-- When implementing provider-dependent parsing, completion, navigation, execution, or UI behavior, validate the impact on both providers.
-- When adding database-dependent behavior tests, cover both SQL Server and MySQL whenever applicable.
+- Every new feature must support all currently supported database providers, unless the limitation is explicitly documented and approved.
+- Do not introduce behavior that works for only a subset of supported providers without handling the remaining providers, or without explicitly documenting and approving the limitation.
+- When implementing provider-dependent parsing, completion, navigation, execution, or UI behavior, validate the impact on all supported providers.
+- When adding database-dependent behavior tests, cover all supported providers whenever applicable.
 - For every new provider added in the future, implement provider tests from the start.
 - New providers must include, at minimum, unit coverage for provider factory wiring, connection settings serialization, schema SQL, and completion/execution behavior where applicable.
-- When feasible, add opt-in integration tests for each new provider using real configured connections, following the same pattern used for SQL Server and MySQL.
+- When feasible, add opt-in integration tests for each supported provider using real configured connections.
 
 ## Documentation
 - When adding a new database provider or significant provider capability, update `README.md` in the same branch.

--- a/DataDeveloper.Data/Interfaces/IConnectionSettings.cs
+++ b/DataDeveloper.Data/Interfaces/IConnectionSettings.cs
@@ -11,5 +11,6 @@ public interface IConnectionSettings
     bool Encrypt { get; set; }
     bool TrustServerCertificate { get; set; }
     bool AllowBlankPassword { get; set; }
+    int StatementTimeoutSeconds { get; set; }
     DatabaseType DatabaseType { get; set; }
 }

--- a/DataDeveloper.Data/Interfaces/IStatementExecutor.cs
+++ b/DataDeveloper.Data/Interfaces/IStatementExecutor.cs
@@ -1,8 +1,15 @@
+using System.Threading;
 using DataDeveloper.Data.Models;
 
 namespace DataDeveloper.Data.Interfaces;
 
 public interface IStatementExecutor
 {
-    Task<IEnumerable<StatementResult>> ExecuteStatement(string sqlStatement, IReadOnlyDictionary<string, object?>? parameters = null);
+    Task<IEnumerable<StatementResult>> ExecuteStatement(
+        string sqlStatement,
+        IReadOnlyDictionary<string, object?>? parameters = null,
+        int? commandTimeoutSeconds = null,
+        CancellationToken cancellationToken = default);
+
+    void Cancel();
 }

--- a/DataDeveloper.Data/Models/ConnectionSettings.cs
+++ b/DataDeveloper.Data/Models/ConnectionSettings.cs
@@ -7,6 +7,8 @@ namespace DataDeveloper.Data.Models;
 
 public class ConnectionSettings : ReactiveObject, IConnectionSettings
 {
+    public const int DefaultStatementTimeoutSeconds = 60;
+
     [Reactive] public Guid Id { get; set; }
     [Reactive] public Guid? CredentialId { get; set; }
     [Reactive] public string Name { get; set; } = string.Empty;
@@ -17,5 +19,6 @@ public class ConnectionSettings : ReactiveObject, IConnectionSettings
     [Reactive] public bool Encrypt { get; set; } = true;
     [Reactive] public bool TrustServerCertificate { get; set; }
     [Reactive] public bool AllowBlankPassword { get; set; }
+    [Reactive] public int StatementTimeoutSeconds { get; set; } = DefaultStatementTimeoutSeconds;
     [Reactive] public DatabaseType DatabaseType { get; set; }
 }

--- a/DataDeveloper.Data/Models/StatementResult.cs
+++ b/DataDeveloper.Data/Models/StatementResult.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
+using System.Collections.ObjectModel;
 
 namespace DataDeveloper.Data.Models;
 
@@ -15,7 +16,8 @@ public class StatementResult
         DbCommand? command,
         string statement,
         Stopwatch watcher,
-        int? recordsAffected = null)
+        int? recordsAffected = null,
+        IReadOnlyDictionary<string, object?>? parameters = null)
     {
         DataReader = dataReader;
         Connection = connection;
@@ -23,6 +25,9 @@ public class StatementResult
         Statement = statement;
         Watcher = watcher;
         RecordsAffected = recordsAffected ?? dataReader?.RecordsAffected ?? 0;
+        Parameters = parameters is null
+            ? null
+            : new ReadOnlyDictionary<string, object?>(new Dictionary<string, object?>(parameters, StringComparer.OrdinalIgnoreCase));
     }
 
     public DbDataReader? DataReader { get; }
@@ -31,6 +36,7 @@ public class StatementResult
     public string Statement { get; }
     public Stopwatch Watcher { get; }
     public int RecordsAffected { get; }
+    public IReadOnlyDictionary<string, object?>? Parameters { get; }
     public bool HasRows => DataReader?.HasRows ?? false;
     public bool HasDataReader => DataReader is not null;
     public bool HasResultSet => (DataReader?.FieldCount ?? 0) > 0;

--- a/DataDeveloper.Data/Models/StatementResult.cs
+++ b/DataDeveloper.Data/Models/StatementResult.cs
@@ -7,11 +7,19 @@ namespace DataDeveloper.Data.Models;
 public class StatementResult
 {
     private bool _isClosed;
+    private bool _cancelRequested;
 
-    public StatementResult(DbDataReader? dataReader, DbConnection? connection, string statement, Stopwatch watcher, int? recordsAffected = null)
+    public StatementResult(
+        DbDataReader? dataReader,
+        DbConnection? connection,
+        DbCommand? command,
+        string statement,
+        Stopwatch watcher,
+        int? recordsAffected = null)
     {
         DataReader = dataReader;
         Connection = connection;
+        Command = command;
         Statement = statement;
         Watcher = watcher;
         RecordsAffected = recordsAffected ?? dataReader?.RecordsAffected ?? 0;
@@ -19,12 +27,26 @@ public class StatementResult
 
     public DbDataReader? DataReader { get; }
     public DbConnection? Connection { get; }
+    public DbCommand? Command { get; }
     public string Statement { get; }
     public Stopwatch Watcher { get; }
     public int RecordsAffected { get; }
     public bool HasRows => DataReader?.HasRows ?? false;
     public bool HasDataReader => DataReader is not null;
     public bool HasResultSet => (DataReader?.FieldCount ?? 0) > 0;
+
+    public void CancelExecution()
+    {
+        _cancelRequested = true;
+        try
+        {
+            Command?.Cancel();
+        }
+        catch
+        {
+            // Providers vary in cancellation support; closing the reader/connection is the fallback.
+        }
+    }
 
     public async Task CloseDataReader()
     {
@@ -35,13 +57,41 @@ public class StatementResult
 
         try
         {
+            if (_cancelRequested)
+                CancelExecution();
+
             if (DataReader is not null)
                 await DataReader.DisposeAsync();
         }
+        catch (Exception) when (_cancelRequested)
+        {
+            // Some providers surface cancellation faults during reader disposal. Treat them as expected.
+        }
         finally
         {
+            if (Command is not null)
+            {
+                try
+                {
+                    await Command.DisposeAsync();
+                }
+                catch (Exception) when (_cancelRequested)
+                {
+                    // Ignore provider cleanup failures after an explicit cancel.
+                }
+            }
+
             if (Connection is not null)
-                await Connection.DisposeAsync();
+            {
+                try
+                {
+                    await Connection.DisposeAsync();
+                }
+                catch (Exception) when (_cancelRequested)
+                {
+                    // Ignore provider cleanup failures after an explicit cancel.
+                }
+            }
         }
     }
 }

--- a/DataDeveloper.Data/Providers/SqlServer/SqlServerConnectionSettings.cs
+++ b/DataDeveloper.Data/Providers/SqlServer/SqlServerConnectionSettings.cs
@@ -7,5 +7,6 @@ public class SqlServerConnectionSettings : ConnectionSettings
 {
     [Reactive]public string Server { get; set; } = string.Empty;
     [Reactive]public string Database { get; set; } = string.Empty;
+    [Reactive]public int Port { get; set; } = 1433;
     [Reactive]public SqlServerAuthenticationMode AuthenticationMode { get; set; } = SqlServerAuthenticationMode.SqlLogin;
 }

--- a/DataDeveloper.Data/Providers/SqlServer/SqlServerDatabaseProvider.cs
+++ b/DataDeveloper.Data/Providers/SqlServer/SqlServerDatabaseProvider.cs
@@ -141,7 +141,7 @@ public class SqlServerDatabaseProvider : DatabaseProviderBase<SqlServerConnectio
     {
         var builder = new SqlConnectionStringBuilder
         {
-            DataSource = ConnectionSettings.Server,
+            DataSource = BuildDataSource(),
             InitialCatalog = string.IsNullOrWhiteSpace(databaseName) ? "master" : databaseName,
             Encrypt = ConnectionSettings.Encrypt,
             TrustServerCertificate = ConnectionSettings.TrustServerCertificate
@@ -158,5 +158,22 @@ public class SqlServerDatabaseProvider : DatabaseProviderBase<SqlServerConnectio
         }
 
         return builder.ConnectionString;
+    }
+
+    private string BuildDataSource()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionSettings.Server))
+            return ConnectionSettings.Server;
+
+        if (ConnectionSettings.Server.Contains(",", StringComparison.Ordinal) ||
+            ConnectionSettings.Server.Contains(":", StringComparison.Ordinal) ||
+            ConnectionSettings.Server.Contains("\\", StringComparison.Ordinal))
+        {
+            return ConnectionSettings.Server;
+        }
+
+        return ConnectionSettings.Port > 0
+            ? $"{ConnectionSettings.Server},{ConnectionSettings.Port}"
+            : ConnectionSettings.Server;
     }
 }

--- a/DataDeveloper.Data/Services/StatementExecutor.cs
+++ b/DataDeveloper.Data/Services/StatementExecutor.cs
@@ -53,7 +53,7 @@ public class StatementExecutor : IStatementExecutor
                 var reader = await command.ExecuteReaderAsync(cancellationToken);
                 watcher.Stop();
 
-                result.Add(new StatementResult(reader, connection, command, statement, watcher));
+                result.Add(new StatementResult(reader, connection, command, statement, watcher, parameters: parameters));
                 ClearActiveCommand(command);
             }
 
@@ -130,12 +130,12 @@ public class StatementExecutor : IStatementExecutor
             {
                 var table = ResultSetMaterializer.MaterializeCurrentResult(reader);
                 watcher.Stop();
-                results.Add(new StatementResult(table.CreateDataReader(), null, null, statement, watcher, table.Rows.Count));
+                results.Add(new StatementResult(table.CreateDataReader(), null, null, statement, watcher, table.Rows.Count, parameters));
             }
             else
             {
                 watcher.Stop();
-                results.Add(new StatementResult(null, null, null, statement, watcher, reader.RecordsAffected));
+                results.Add(new StatementResult(null, null, null, statement, watcher, reader.RecordsAffected, parameters));
             }
         } while (await reader.NextResultAsync(cancellationToken));
 

--- a/DataDeveloper.Data/Services/StatementExecutor.cs
+++ b/DataDeveloper.Data/Services/StatementExecutor.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using System.Diagnostics;
 using System.Data.Common;
+using System.Threading;
 using Dapper;
 using DataDeveloper.Data.Enums;
 using DataDeveloper.Data.Interfaces;
@@ -12,6 +13,9 @@ public class StatementExecutor : IStatementExecutor
 {
     private readonly IConnectionSettings _connectionSettings;
     private readonly IDatabaseProvider _databaseProvider;
+    private readonly object _activeCommandLock = new();
+    private DbCommand? _activeCommand;
+    private int _cancelRequested;
     
     public StatementExecutor(IConnectionSettings connectionSettings)
     {
@@ -19,37 +23,74 @@ public class StatementExecutor : IStatementExecutor
         _databaseProvider = _connectionSettings.GetDatabaseProvider();
     }
 
-    public async Task<IEnumerable<StatementResult>> ExecuteStatement(string sqlStatement, IReadOnlyDictionary<string, object?>? parameters = null)
+    public async Task<IEnumerable<StatementResult>> ExecuteStatement(
+        string sqlStatement,
+        IReadOnlyDictionary<string, object?>? parameters = null,
+        int? commandTimeoutSeconds = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
             var result = new List<StatementResult>();
             var statements = StatementSplitter.SplitStatements(sqlStatement);
-            var dapperParameters = CreateParameters(parameters);
 
             foreach (var statement in statements)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 if (StatementExecutionClassifier.RequiresMaterialization(statement))
                 {
-                    var materializedResults = await ExecuteMaterializedStatement(statement, parameters);
+                    var materializedResults = await ExecuteMaterializedStatement(statement, parameters, commandTimeoutSeconds, cancellationToken);
                     result.AddRange(materializedResults);
                     continue;
                 }
 
                 var watcher = Stopwatch.StartNew();
                 var connection = _databaseProvider.GetConnection();
-                var reader = await connection.ExecuteReaderAsync(statement, param: dapperParameters, commandType: CommandType.Text);
+                await connection.OpenAsync(cancellationToken);
+                var command = CreateCommand(connection, statement, parameters, commandTimeoutSeconds);
+                SetActiveCommand(command);
+                var reader = await command.ExecuteReaderAsync(cancellationToken);
                 watcher.Stop();
 
-                result.Add(new StatementResult(reader, connection, statement, watcher));
+                result.Add(new StatementResult(reader, connection, command, statement, watcher));
+                ClearActiveCommand(command);
             }
 
             return result;
+        }
+        catch (OperationCanceledException)
+        {
+            Cancel();
+            throw;
+        }
+        catch (Exception e) when (IsCancellationException(e, cancellationToken))
+        {
+            throw new OperationCanceledException("Statement execution cancelled.", e, cancellationToken);
         }
         catch (Exception e)
         {
             Console.WriteLine(e);
             throw;
+        }
+    }
+
+    public void Cancel()
+    {
+        Interlocked.Exchange(ref _cancelRequested, 1);
+        DbCommand? command;
+        lock (_activeCommandLock)
+        {
+            command = _activeCommand;
+        }
+
+        try
+        {
+            command?.Cancel();
+        }
+        catch
+        {
+            // Provider cancellation support is best-effort.
         }
     }
 
@@ -67,39 +108,53 @@ public class StatementExecutor : IStatementExecutor
         return dapperParameters;
     }
 
-    private async Task<IEnumerable<StatementResult>> ExecuteMaterializedStatement(string statement, IReadOnlyDictionary<string, object?>? parameters)
+    private async Task<IEnumerable<StatementResult>> ExecuteMaterializedStatement(
+        string statement,
+        IReadOnlyDictionary<string, object?>? parameters,
+        int? commandTimeoutSeconds,
+        CancellationToken cancellationToken)
     {
         var results = new List<StatementResult>();
         await using var connection = _databaseProvider.GetConnection();
-        await connection.OpenAsync();
-        await using var command = CreateCommand(connection, statement, parameters);
-        await using var reader = await command.ExecuteReaderAsync();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = CreateCommand(connection, statement, parameters, commandTimeoutSeconds);
+        SetActiveCommand(command);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
         do
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var watcher = Stopwatch.StartNew();
 
             if (reader.FieldCount > 0)
             {
                 var table = ResultSetMaterializer.MaterializeCurrentResult(reader);
                 watcher.Stop();
-                results.Add(new StatementResult(table.CreateDataReader(), null, statement, watcher, table.Rows.Count));
+                results.Add(new StatementResult(table.CreateDataReader(), null, null, statement, watcher, table.Rows.Count));
             }
             else
             {
                 watcher.Stop();
-                results.Add(new StatementResult(null, null, statement, watcher, reader.RecordsAffected));
+                results.Add(new StatementResult(null, null, null, statement, watcher, reader.RecordsAffected));
             }
-        } while (await reader.NextResultAsync());
+        } while (await reader.NextResultAsync(cancellationToken));
+
+        ClearActiveCommand(command);
 
         return results;
     }
 
-    private DbCommand CreateCommand(DbConnection connection, string statement, IReadOnlyDictionary<string, object?>? parameters)
+    private DbCommand CreateCommand(
+        DbConnection connection,
+        string statement,
+        IReadOnlyDictionary<string, object?>? parameters,
+        int? commandTimeoutSeconds = null)
     {
         var command = connection.CreateCommand();
         command.CommandText = statement;
         command.CommandType = CommandType.Text;
+        if (commandTimeoutSeconds.HasValue)
+            command.CommandTimeout = commandTimeoutSeconds.Value;
 
         if (parameters is null)
             return command;
@@ -126,5 +181,55 @@ public class StatementExecutor : IStatementExecutor
     private static string TrimParameterPrefix(string name)
     {
         return name.TrimStart('@', ':');
+    }
+
+    private void SetActiveCommand(DbCommand command)
+    {
+        Interlocked.Exchange(ref _cancelRequested, 0);
+        lock (_activeCommandLock)
+        {
+            _activeCommand = command;
+        }
+    }
+
+    private void ClearActiveCommand(DbCommand command)
+    {
+        lock (_activeCommandLock)
+        {
+            if (ReferenceEquals(_activeCommand, command))
+                _activeCommand = null;
+        }
+    }
+
+    private bool IsCancellationException(Exception exception, CancellationToken cancellationToken)
+    {
+        if (!cancellationToken.IsCancellationRequested && Interlocked.CompareExchange(ref _cancelRequested, 0, 0) == 0)
+            return false;
+
+        foreach (var current in EnumerateExceptions(exception))
+        {
+            if (current is OperationCanceledException or TaskCanceledException)
+                return true;
+
+            var message = current.Message;
+            if (message.Contains("The operation was canceled", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("Operation cancelled", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("Operation canceled", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("Command cancelled", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("Command canceled", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("Query execution was interrupted", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("A severe error occurred on the current command", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Exception> EnumerateExceptions(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+            yield return current;
     }
 }

--- a/DataDeveloper.NextGrid/BulkObservableCollection.cs
+++ b/DataDeveloper.NextGrid/BulkObservableCollection.cs
@@ -1,0 +1,122 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace DataDeveloper.NextGrid;
+
+public class BulkObservableCollection<T> : ObservableCollection<T>
+{
+    private int _updateDepth;
+    private bool _hasCollectionChanges;
+    private bool _hasCountChange;
+    private bool _hasIndexerChange;
+    private NotifyCollectionChangedEventArgs? _deferredCollectionChangedEventArgs;
+
+    public void BeginUpdate()
+    {
+        _updateDepth++;
+    }
+
+    public void EndUpdate()
+    {
+        if (_updateDepth == 0)
+            return;
+
+        _updateDepth--;
+        if (_updateDepth > 0 || !_hasCollectionChanges)
+            return;
+
+        FlushDeferredNotifications();
+    }
+
+    public void AddRange(IEnumerable<T> items)
+    {
+        var materializedItems = items.ToList();
+        if (materializedItems.Count == 0)
+            return;
+
+        var startIndex = Count;
+        BeginUpdate();
+        try
+        {
+            foreach (var item in materializedItems)
+                Items.Add(item);
+
+            if (_updateDepth > 0)
+            {
+                _hasCollectionChanges = true;
+                _hasCountChange = true;
+                _hasIndexerChange = true;
+                _deferredCollectionChangedEventArgs = new NotifyCollectionChangedEventArgs(
+                    NotifyCollectionChangedAction.Add,
+                    materializedItems,
+                    startIndex);
+            }
+        }
+        finally
+        {
+            EndUpdate();
+        }
+    }
+
+    protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+    {
+        if (_updateDepth > 0)
+        {
+            _hasCollectionChanges = true;
+            _deferredCollectionChangedEventArgs = MergeDeferredEvent(_deferredCollectionChangedEventArgs, e);
+            return;
+        }
+
+        base.OnCollectionChanged(e);
+    }
+
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        if (_updateDepth > 0)
+        {
+            if (e.PropertyName == nameof(Count))
+                _hasCountChange = true;
+
+            if (e.PropertyName == "Item[]")
+                _hasIndexerChange = true;
+
+            return;
+        }
+
+        base.OnPropertyChanged(e);
+    }
+
+    private void FlushDeferredNotifications()
+    {
+        if (_hasCountChange)
+            base.OnPropertyChanged(new PropertyChangedEventArgs(nameof(Count)));
+
+        if (_hasIndexerChange)
+            base.OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+
+        base.OnCollectionChanged(_deferredCollectionChangedEventArgs ??
+                                 new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+
+        _hasCollectionChanges = false;
+        _hasCountChange = false;
+        _hasIndexerChange = false;
+        _deferredCollectionChangedEventArgs = null;
+    }
+
+    private static NotifyCollectionChangedEventArgs MergeDeferredEvent(
+        NotifyCollectionChangedEventArgs? current,
+        NotifyCollectionChangedEventArgs next)
+    {
+        if (current is null)
+            return next;
+
+        if (current.Action == NotifyCollectionChangedAction.Add &&
+            next.Action == NotifyCollectionChangedAction.Add)
+        {
+            return new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+        }
+
+        return new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+    }
+}

--- a/DataDeveloper.NextGrid/UI/GridSelectionChangedEventArgs.cs
+++ b/DataDeveloper.NextGrid/UI/GridSelectionChangedEventArgs.cs
@@ -1,0 +1,14 @@
+namespace DataDeveloper.NextGrid.UI;
+
+public sealed class GridSelectionChangedEventArgs : EventArgs
+{
+    public GridSelectionChangedEventArgs(GridCellAddress? focusCell, IReadOnlyList<GridSelectionRange> ranges)
+    {
+        FocusCell = focusCell;
+        Ranges = ranges;
+    }
+
+    public GridCellAddress? FocusCell { get; }
+
+    public IReadOnlyList<GridSelectionRange> Ranges { get; }
+}

--- a/DataDeveloper.NextGrid/UI/GridSelectionStatusFormatter.cs
+++ b/DataDeveloper.NextGrid/UI/GridSelectionStatusFormatter.cs
@@ -1,0 +1,36 @@
+namespace DataDeveloper.NextGrid.UI;
+
+internal static class GridSelectionStatusFormatter
+{
+    public static string Format(GridCellAddress? focusCell, IReadOnlyList<GridSelectionRange> ranges)
+    {
+        if (focusCell is null)
+            return "Cell=nothing";
+
+        if (TryGetSelectedSize(ranges, out var rowCount, out var columnCount) &&
+            (rowCount > 1 || columnCount > 1))
+        {
+            return $"Selected={rowCount:N0} row(s) x {columnCount:N0} column(s)";
+        }
+
+        return $"Cell={focusCell.Value.Row + 1:N0}:{focusCell.Value.Column + 1:N0}";
+    }
+
+    private static bool TryGetSelectedSize(IReadOnlyList<GridSelectionRange> ranges, out int rowCount, out int columnCount)
+    {
+        rowCount = 0;
+        columnCount = 0;
+
+        if (ranges.Count == 0)
+            return false;
+
+        var topRow = ranges.Min(range => range.TopRow);
+        var bottomRow = ranges.Max(range => range.BottomRow);
+        var leftColumn = ranges.Min(range => range.LeftColumn);
+        var rightColumn = ranges.Max(range => range.RightColumn);
+
+        rowCount = bottomRow - topRow + 1;
+        columnCount = rightColumn - leftColumn + 1;
+        return rowCount > 0 && columnCount > 0;
+    }
+}

--- a/DataDeveloper.NextGrid/UI/NextGridControl.cs
+++ b/DataDeveloper.NextGrid/UI/NextGridControl.cs
@@ -98,6 +98,12 @@ public sealed class NextGridControl : UserControl
     public static readonly StyledProperty<int> SelectedRowIndexProperty =
         AvaloniaProperty.Register<NextGridControl, int>(nameof(SelectedRowIndex), defaultValue: -1, defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
 
+    public static readonly StyledProperty<string> SelectionStatusTextProperty =
+        AvaloniaProperty.Register<NextGridControl, string>(
+            nameof(SelectionStatusText),
+            defaultValue: "Cell=nothing",
+            defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
+
     public ObservableCollection<string> Headers
     {
         get => GetValue(HeadersProperty);
@@ -180,6 +186,12 @@ public sealed class NextGridControl : UserControl
     {
         get => GetValue(SelectedRowIndexProperty);
         set => SetValue(SelectedRowIndexProperty, value);
+    }
+
+    public string SelectionStatusText
+    {
+        get => GetValue(SelectionStatusTextProperty);
+        set => SetValue(SelectionStatusTextProperty, value);
     }
 
     public event EventHandler<GridCellEditCommittedEventArgs>? CellEditCommitted;
@@ -346,6 +358,7 @@ public sealed class NextGridControl : UserControl
         _presenter.PointerExited += OnPresenterPointerExited;
         _scrollViewer.LayoutUpdated += OnScrollViewerLayoutUpdated;
         _presenter.FocusedCellChanged += OnPresenterFocusedCellChanged;
+        _presenter.SelectionChanged += OnPresenterSelectionChanged;
         _presenter.CellEditRequested += OnPresenterCellEditRequested;
         _presenter.CellEditCommitted += OnPresenterCellEditCommitted;
         _presenter.CellEditCanceled += OnPresenterCellEditCanceled;
@@ -455,6 +468,11 @@ public sealed class NextGridControl : UserControl
     private void OnPresenterFocusedCellChanged(object? sender, GridFocusedCellChangedEventArgs e)
     {
         SelectedRowIndex = e.Cell?.Row ?? -1;
+    }
+
+    private void OnPresenterSelectionChanged(object? sender, GridSelectionChangedEventArgs e)
+    {
+        SelectionStatusText = GridSelectionStatusFormatter.Format(e.FocusCell, e.Ranges);
     }
 
     private void OnPresenterPointerMoved(object? sender, PointerEventArgs e)

--- a/DataDeveloper.NextGrid/UI/NextGridPresenter.cs
+++ b/DataDeveloper.NextGrid/UI/NextGridPresenter.cs
@@ -203,6 +203,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
 
     public event EventHandler? ScrollInvalidated;
     public event EventHandler<GridFocusedCellChangedEventArgs>? FocusedCellChanged;
+    public event EventHandler<GridSelectionChangedEventArgs>? SelectionChanged;
     public event EventHandler<GridCellEditRequestedEventArgs>? CellEditRequested;
     public event EventHandler<GridCellEditCommittedEventArgs>? CellEditCommitted;
     public event EventHandler? CellEditCanceled;
@@ -447,6 +448,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         {
             _tableController.Selection.SelectAll(Rows.Count, Headers.Count);
             Focus();
+            RaiseSelectionChanged();
             InvalidateVisual();
             return;
         }
@@ -460,6 +462,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         }
 
         RaiseFocusedCellChanged();
+        RaiseSelectionChanged();
 
         Focus();
         InvalidateVisual();
@@ -525,6 +528,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         }
 
         InvalidateVisual();
+        RaiseSelectionChanged();
         e.Handled = true;
     }
 
@@ -601,6 +605,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
             : _tableController.MoveFocus(direction.Value, step);
         Offset = ToScrollViewerOffset(result.HorizontalOffset, result.VerticalOffset);
         RaiseFocusedCellChanged();
+        RaiseSelectionChanged();
         InvalidateVisual();
         e.Handled = true;
     }
@@ -681,11 +686,19 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         FocusedCellChanged?.Invoke(this, new GridFocusedCellChangedEventArgs(_tableController.Selection.FocusCell));
     }
 
+    private void RaiseSelectionChanged()
+    {
+        SelectionChanged?.Invoke(
+            this,
+            new GridSelectionChangedEventArgs(_tableController.Selection.FocusCell, _tableController.Selection.Ranges.ToArray()));
+    }
+
     private void AdvanceFocusAfterEdit(GridCellAddress cell)
     {
         if (cell.Column + 1 >= Headers.Count)
         {
             RaiseFocusedCellChanged();
+            RaiseSelectionChanged();
             return;
         }
 
@@ -694,6 +707,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         _tableController.Selection.SelectCell(visible.Cell);
         Offset = ToScrollViewerOffset(visible.HorizontalOffset, visible.VerticalOffset);
         RaiseFocusedCellChanged();
+        RaiseSelectionChanged();
     }
 
     private void DrawHeaders(DrawingContext context, GridVisibleRange range)
@@ -1042,6 +1056,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         UpdateControllerViewport();
         var hit = _tableController.HitTest(point.X, point.Y);
         _tableController.HandlePointerSelection(hit, KeyModifiers.None);
+        RaiseSelectionChanged();
     }
 
     internal GridHitTestResult HitTestAtLocalPointForTest(Point point)
@@ -1057,6 +1072,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         UpdateControllerViewport();
         _tableController.Selection.SelectCell(start);
         _tableController.Selection.ExtendToCell(end);
+        RaiseSelectionChanged();
     }
 
     internal bool SelectionContainsForTest(GridCellAddress cell)

--- a/DataDeveloper.NextGrid/UI/NextGridPresenter.cs
+++ b/DataDeveloper.NextGrid/UI/NextGridPresenter.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Media;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using DataDeveloper.NextGrid.Clipboard;
 using DataDeveloper.NextGrid.Editors;
@@ -39,6 +40,10 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
     private double _lastMeasuredRowHeaderWidth = 44;
     private bool _isSelecting;
     private GridRegionKind _selectionOriginRegion;
+    private bool _isRefreshScheduled;
+    private bool _pendingScrollInvalidation;
+    private bool _pendingMeasureInvalidation;
+    private bool _pendingVisualInvalidation;
     private ObservableCollection<int>? _readOnlyColumnsSubscription;
 
     private ObservableCollection<string>? _headersSubscription;
@@ -176,8 +181,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
                 return;
 
             _offset = clamped;
-            RaiseScrollInvalidated(EventArgs.Empty);
-            InvalidateVisual();
+            RequestRefresh(scroll: true, visual: true);
         }
     }
 
@@ -340,24 +344,39 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
         {
             _autoWidthPending = true;
             _rowRenderCache.Clear();
-            InvalidateMeasure();
-            InvalidateVisual();
+            RequestRefresh(measure: true, visual: true);
         }
 
         if (e.Property == BoundsProperty)
         {
             Offset = ClampOffset(Offset);
-            RaiseScrollInvalidated(EventArgs.Empty);
-            InvalidateVisual();
+            RequestRefresh(scroll: true, visual: true);
         }
     }
 
     private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
+        var isRowsChange = ReferenceEquals(sender, Rows);
+        var shouldInvalidateVisual = true;
+
+        if (isRowsChange)
+        {
+            _tableController.SetDimensions(Rows.Count, Headers.Count);
+            UpdateControllerViewport();
+        }
+
         if (ReferenceEquals(sender, Rows))
         {
-            _autoWidthPending = true;
-            _rowRenderCache.Clear();
+            if (e.Action == NotifyCollectionChangedAction.Add && e.NewItems is not null && !_autoWidthPending)
+            {
+                TrackAddedRowWidths(e.NewItems);
+                shouldInvalidateVisual = ShouldInvalidateVisualForAddedRows(e);
+            }
+            else
+            {
+                _autoWidthPending = true;
+                _rowRenderCache.Clear();
+            }
         }
 
         if (e.Action == NotifyCollectionChangedAction.Reset)
@@ -365,12 +384,43 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
 
         var rowHeaderWidthChanged = Math.Abs(GetRowHeaderWidth() - _lastMeasuredRowHeaderWidth) > 0.01d;
         Offset = ClampOffset(Offset);
-        RaiseScrollInvalidated(EventArgs.Empty);
+        RequestRefresh(scroll: true);
 
         if (e.Action == NotifyCollectionChangedAction.Reset || rowHeaderWidthChanged)
-            InvalidateMeasure();
+            RequestRefresh(measure: true);
 
-        InvalidateVisual();
+        if (shouldInvalidateVisual || rowHeaderWidthChanged || !isRowsChange)
+            RequestRefresh(visual: true);
+    }
+
+    private bool ShouldInvalidateVisualForAddedRows(NotifyCollectionChangedEventArgs e)
+    {
+        if (e.NewStartingIndex < 0)
+            return true;
+
+        var visibleRows = _tableController.GetRowRenderRange();
+        return e.NewStartingIndex < visibleRows.EndExclusive;
+    }
+
+    private void TrackAddedRowWidths(System.Collections.IList newItems)
+    {
+        _columnLayout.EnsureColumnCount(Headers.Count);
+
+        foreach (var item in newItems)
+        {
+            if (item is not IReadOnlyList<object?> row)
+                continue;
+
+            for (var columnIndex = 0; columnIndex < Headers.Count; columnIndex++)
+            {
+                var value = columnIndex < row.Count ? row[columnIndex] : null;
+                var renderer = GetColumnRenderer(columnIndex, value);
+                var width = renderer.MeasureWidth(value, GridRendererContext.Default, text => MeasureTextWidth(text, CellForeground)) + 16;
+                _columnLayout.TrackWidth(columnIndex, width);
+            }
+        }
+
+        _lastMeasuredRowHeaderWidth = GetRowHeaderWidth();
     }
 
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -441,9 +491,7 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
             if (_columnLayout.SetWidth(_resizingColumnIndex.Value, width))
             {
                 _rowRenderCache.InvalidateColumn(_resizingColumnIndex.Value);
-                RaiseScrollInvalidated(EventArgs.Empty);
-                InvalidateMeasure();
-                InvalidateVisual();
+                RequestRefresh(scroll: true, measure: true, visual: true);
             }
 
             e.Handled = true;
@@ -849,6 +897,37 @@ internal sealed class NextGridPresenter : Control, IScrollable, ILogicalScrollab
 
         current = next;
         current.CollectionChanged += handler;
+    }
+
+    private void RequestRefresh(bool scroll = false, bool measure = false, bool visual = false)
+    {
+        _pendingScrollInvalidation |= scroll;
+        _pendingMeasureInvalidation |= measure;
+        _pendingVisualInvalidation |= visual;
+
+        if (_isRefreshScheduled)
+            return;
+
+        _isRefreshScheduled = true;
+        Dispatcher.UIThread.Post(FlushRefreshRequests, DispatcherPriority.Render);
+    }
+
+    private void FlushRefreshRequests()
+    {
+        _isRefreshScheduled = false;
+
+        if (_pendingScrollInvalidation)
+            RaiseScrollInvalidated(EventArgs.Empty);
+
+        if (_pendingMeasureInvalidation)
+            InvalidateMeasure();
+
+        if (_pendingVisualInvalidation)
+            InvalidateVisual();
+
+        _pendingScrollInvalidation = false;
+        _pendingMeasureInvalidation = false;
+        _pendingVisualInvalidation = false;
     }
 
     private void UpdateControllerViewport()

--- a/DataDeveloper.Tests/NextGrid/BulkObservableCollectionTests.cs
+++ b/DataDeveloper.Tests/NextGrid/BulkObservableCollectionTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Specialized;
+using DataDeveloper.NextGrid;
+using Xunit;
+
+namespace DataDeveloper.Tests.NextGrid;
+
+public sealed class BulkObservableCollectionTests
+{
+    [Fact]
+    public void AddRange_RaisesSingleResetNotification()
+    {
+        var collection = new BulkObservableCollection<int>();
+        var notifications = new List<NotifyCollectionChangedEventArgs>();
+
+        collection.CollectionChanged += (_, args) => notifications.Add(args);
+
+        collection.AddRange([1, 2, 3]);
+
+        Assert.Equal([1, 2, 3], collection);
+        Assert.Single(notifications);
+        Assert.Equal(NotifyCollectionChangedAction.Add, notifications[0].Action);
+        Assert.NotNull(notifications[0].NewItems);
+        Assert.Equal(3, notifications[0].NewItems!.Count);
+    }
+
+    [Fact]
+    public void BeginUpdate_EndUpdate_DefersNotificationsUntilCompleted()
+    {
+        var collection = new BulkObservableCollection<int>();
+        var notifications = new List<NotifyCollectionChangedEventArgs>();
+
+        collection.CollectionChanged += (_, args) => notifications.Add(args);
+
+        collection.BeginUpdate();
+        collection.Add(1);
+        collection.Add(2);
+        Assert.Empty(notifications);
+
+        collection.EndUpdate();
+
+        Assert.Equal([1, 2], collection);
+        Assert.Single(notifications);
+        Assert.Equal(NotifyCollectionChangedAction.Reset, notifications[0].Action);
+    }
+}

--- a/DataDeveloper.Tests/NextGrid/UI/NextGridControlUiTests.cs
+++ b/DataDeveloper.Tests/NextGrid/UI/NextGridControlUiTests.cs
@@ -110,6 +110,51 @@ public sealed class NextGridControlUiTests
     }
 
     [AvaloniaFact]
+    public void InitialSelectionStatus_ShowsNothing()
+    {
+        var grid = CreateGrid(rowCount: 20, columnCount: 4);
+        var window = CreateWindow(grid, 900, 420);
+
+        window.Show();
+        ExecuteLayout(window);
+
+        Assert.Equal("Cell=nothing", grid.SelectionStatusText);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void FirstClick_UpdatesSelectionStatusWithCellCoordinate()
+    {
+        var grid = CreateGrid(rowCount: 20, columnCount: 4);
+        var window = CreateWindow(grid, 900, 420);
+
+        window.Show();
+        ExecuteLayout(window);
+
+        var cell = grid.GetCellBoundsForTest(2, 1);
+        var clickPoint = new Point(cell.X + Math.Min(12, cell.Width / 2), cell.Y + Math.Min(12, cell.Height / 2));
+        grid.SelectCellAtLocalPointForTest(clickPoint);
+
+        Assert.Equal("Cell=3:2", grid.SelectionStatusText);
+        window.Close();
+    }
+
+    [AvaloniaFact]
+    public void DragSelection_UpdatesSelectionStatusWithSelectedSize()
+    {
+        var grid = CreateGrid(rowCount: 20, columnCount: 6);
+        var window = CreateWindow(grid, 900, 420);
+
+        window.Show();
+        ExecuteLayout(window);
+
+        grid.DragSelectCellsForTest(new GridCellAddress(1, 1), new GridCellAddress(3, 4));
+
+        Assert.Equal("Selected=3 row(s) x 4 column(s)", grid.SelectionStatusText);
+        window.Close();
+    }
+
+    [AvaloniaFact]
     public void BeginEditAndCommit_UpdatesCellValue()
     {
         var grid = CreateGrid(rowCount: 20, columnCount: 4);

--- a/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
+++ b/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
@@ -28,6 +28,7 @@ public class ConnectionSettingsConverterTests
                               "Name":"SqlServer",
                               "DatabaseType":"SqlServer",
                               "Server":"localhost",
+                              "Port":1433,
                               "Database":"master",
                               "AuthenticationMode":"WindowsIntegrated",
                               "User":"sa",
@@ -42,6 +43,7 @@ public class ConnectionSettingsConverterTests
         var typed = Assert.IsType<SqlServerConnectionSettings>(connection);
         Assert.Equal(DatabaseType.SqlServer, typed.DatabaseType);
         Assert.Equal("localhost", typed.Server);
+        Assert.Equal(1433, typed.Port);
         Assert.Equal(SqlServerAuthenticationMode.WindowsIntegrated, typed.AuthenticationMode);
     }
 
@@ -146,6 +148,7 @@ public class ConnectionSettingsConverterTests
             Name = "SqlServer",
             DatabaseType = DatabaseType.SqlServer,
             Server = "localhost",
+            Port = 1433,
             Database = "master",
             AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
             User = "sa",
@@ -159,6 +162,7 @@ public class ConnectionSettingsConverterTests
 
         var typed = Assert.IsType<SqlServerConnectionSettings>(deserialized);
         Assert.Equal("localhost", typed.Server);
+        Assert.Equal(1433, typed.Port);
         Assert.Equal(DatabaseType.SqlServer, typed.DatabaseType);
         Assert.Equal(SqlServerAuthenticationMode.WindowsIntegrated, typed.AuthenticationMode);
     }

--- a/DataDeveloper.Tests/Providers/SqlServerDatabaseProviderTests.cs
+++ b/DataDeveloper.Tests/Providers/SqlServerDatabaseProviderTests.cs
@@ -12,6 +12,7 @@ public class SqlServerDatabaseProviderTests
         var provider = new SqlServerDatabaseProvider(new SqlServerConnectionSettings
         {
             Server = "localhost",
+            Port = 1433,
             Database = "master",
             AuthenticationMode = SqlServerAuthenticationMode.SqlLogin,
             User = "sa",
@@ -24,7 +25,7 @@ public class SqlServerDatabaseProviderTests
 
         var sqlConnection = Assert.IsType<SqlConnection>(connection);
         var builder = new SqlConnectionStringBuilder(sqlConnection.ConnectionString);
-        Assert.Equal("localhost", builder.DataSource);
+        Assert.Equal("localhost,1433", builder.DataSource);
         Assert.Equal("master", builder.InitialCatalog);
         Assert.True(builder.Encrypt);
         Assert.False(builder.TrustServerCertificate);
@@ -58,6 +59,26 @@ public class SqlServerDatabaseProviderTests
         Assert.True(builder.TrustServerCertificate);
         Assert.True(string.IsNullOrEmpty(builder.UserID));
         Assert.True(string.IsNullOrEmpty(builder.Password));
+    }
+
+    [Fact]
+    public void GetConnection_PreservesExplicitServerEndpoint_WhenPortIsAlreadyEmbedded()
+    {
+        var provider = new SqlServerDatabaseProvider(new SqlServerConnectionSettings
+        {
+            Server = "localhost,14333",
+            Port = 1433,
+            Database = "master",
+            AuthenticationMode = SqlServerAuthenticationMode.SqlLogin,
+            User = "sa",
+            Password = "pwd"
+        });
+
+        var connection = provider.GetConnection();
+
+        var sqlConnection = Assert.IsType<SqlConnection>(connection);
+        var builder = new SqlConnectionStringBuilder(sqlConnection.ConnectionString);
+        Assert.Equal("localhost,14333", builder.DataSource);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/SqlCompletionProviderTests.cs
+++ b/DataDeveloper.Tests/SqlCompletionProviderTests.cs
@@ -391,6 +391,7 @@ public class SqlCompletionProviderTests
         public bool Encrypt { get; set; }
         public bool TrustServerCertificate { get; set; }
         public bool AllowBlankPassword { get; set; }
+        public int StatementTimeoutSeconds { get; set; } = ConnectionSettings.DefaultStatementTimeoutSeconds;
         public DatabaseType DatabaseType { get; set; }
     }
 }

--- a/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
+++ b/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
@@ -73,6 +73,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
             AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
             User = "sa",
             Password = "secret",
+            StatementTimeoutSeconds = 120,
             Encrypt = true,
             TrustServerCertificate = false
         };
@@ -87,6 +88,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
             Port = 3307,
             User = "root",
             Password = "mysql-secret",
+            StatementTimeoutSeconds = 240,
             Encrypt = false,
             TrustServerCertificate = true
         };
@@ -101,6 +103,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(sqlServer.Server, loadedSqlServer.Server);
         Assert.Equal(sqlServer.Database, loadedSqlServer.Database);
         Assert.Equal(sqlServer.AuthenticationMode, loadedSqlServer.AuthenticationMode);
+        Assert.Equal(sqlServer.StatementTimeoutSeconds, loadedSqlServer.StatementTimeoutSeconds);
         repository.LoadPassword(loadedSqlServer);
         Assert.Equal(sqlServer.Password, loadedSqlServer.Password);
 
@@ -109,8 +112,33 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(mySql.Server, loadedMySql.Server);
         Assert.Equal(mySql.Database, loadedMySql.Database);
         Assert.Equal(mySql.Port, loadedMySql.Port);
+        Assert.Equal(mySql.StatementTimeoutSeconds, loadedMySql.StatementTimeoutSeconds);
         repository.LoadPassword(loadedMySql);
         Assert.Equal(mySql.Password, loadedMySql.Password);
+    }
+
+    [Fact]
+    public void LoadAll_UsesDefaultStatementTimeout_WhenValueIsMissingOrInvalid()
+    {
+        var repository = CreateRepository(secretStore: new InMemorySecretStore());
+        var connection = new SqlServerConnectionSettings
+        {
+            Id = Guid.NewGuid(),
+            Name = "SQL",
+            DatabaseType = DatabaseType.SqlServer,
+            Server = "sql.local",
+            Database = "master",
+            User = "sa",
+            Password = "secret",
+            StatementTimeoutSeconds = 0
+        };
+
+        repository.Save(connection);
+
+        var loaded = repository.LoadAll();
+        var loadedSqlServer = Assert.IsType<SqlServerConnectionSettings>(Assert.Single(loaded));
+
+        Assert.Equal(ConnectionSettings.DefaultStatementTimeoutSeconds, loadedSqlServer.StatementTimeoutSeconds);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
+++ b/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
@@ -70,6 +70,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
             DatabaseType = DatabaseType.SqlServer,
             Server = "sql.local",
             Database = "master",
+            Port = 1433,
             AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
             User = "sa",
             Password = "secret",
@@ -102,6 +103,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(sqlServer.CredentialId, loadedSqlServer.CredentialId);
         Assert.Equal(sqlServer.Server, loadedSqlServer.Server);
         Assert.Equal(sqlServer.Database, loadedSqlServer.Database);
+        Assert.Equal(sqlServer.Port, loadedSqlServer.Port);
         Assert.Equal(sqlServer.AuthenticationMode, loadedSqlServer.AuthenticationMode);
         Assert.Equal(sqlServer.StatementTimeoutSeconds, loadedSqlServer.StatementTimeoutSeconds);
         repository.LoadPassword(loadedSqlServer);
@@ -368,7 +370,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
                                             0,
                                             'sql.local',
                                             'master',
-                                            null,
+                                            1433,
                                             '2026-04-08T00:00:00.0000000Z',
                                             '2026-04-08T00:00:00.0000000Z'
                                         );
@@ -381,6 +383,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         var loaded = Assert.IsType<SqlServerConnectionSettings>(Assert.Single(repository.LoadAll()));
 
         Assert.Equal(SqlServerAuthenticationMode.SqlLogin, loaded.AuthenticationMode);
+        Assert.Equal(1433, loaded.Port);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/TabDataGridViewModelTests.cs
+++ b/DataDeveloper.Tests/TabDataGridViewModelTests.cs
@@ -1,0 +1,104 @@
+using System.Diagnostics;
+using System.Reflection;
+using DataDeveloper.Data.Enums;
+using DataDeveloper.Data.Interfaces;
+using DataDeveloper.Data.Models;
+using DataDeveloper.Interfaces;
+using DataDeveloper.Services;
+using DataDeveloper.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DataDeveloper.Tests;
+
+public class TabDataGridViewModelTests
+{
+    [Fact]
+    public async Task RefreshDataAsync_ReusesStatementParameters()
+    {
+        var executor = new CapturingStatementExecutor();
+        var services = new ServiceCollection();
+        services.AddSingleton<IEventAggregatorService, EventAggregatorService>();
+        var serviceProvider = services.BuildServiceProvider();
+
+        var parameters = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["IntegrationId"] = Guid.Parse("c681c0c4-aa79-4aba-9b94-665f6f7ebcf7")
+        };
+
+        var viewModel = new TestTabDataGridViewModel(
+            new ConnectionSettings
+            {
+                DatabaseType = DatabaseType.SqlServer,
+                Name = "Test"
+            },
+            new StatementResult(
+                dataReader: null,
+                connection: null,
+                command: null,
+                statement: "select * from Integration where id = @IntegrationId",
+                watcher: new Stopwatch(),
+                parameters: parameters),
+            selectedPage: 100,
+            name: "result 01",
+            canClose: true,
+            serviceProvider: serviceProvider,
+            messageTargetId: Guid.NewGuid(),
+            statementExecutor: executor);
+
+        var refreshMethod = typeof(TabDataGridViewModel).GetMethod("RefreshDataAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(refreshMethod);
+
+        var refreshTask = Assert.IsAssignableFrom<Task>(refreshMethod!.Invoke(viewModel, null));
+        await refreshTask;
+
+        Assert.Equal("select * from Integration where id = @IntegrationId", executor.LastSql);
+        Assert.NotNull(executor.LastParameters);
+        Assert.Equal(parameters["IntegrationId"], executor.LastParameters!["IntegrationId"]);
+    }
+
+    private sealed class CapturingStatementExecutor : IStatementExecutor
+    {
+        public string? LastSql { get; private set; }
+        public IReadOnlyDictionary<string, object?>? LastParameters { get; private set; }
+
+        public Task<IEnumerable<StatementResult>> ExecuteStatement(
+            string sqlStatement,
+            IReadOnlyDictionary<string, object?>? parameters = null,
+            int? commandTimeoutSeconds = null,
+            CancellationToken cancellationToken = default)
+        {
+            LastSql = sqlStatement;
+            LastParameters = parameters;
+            return Task.FromResult<IEnumerable<StatementResult>>([]);
+        }
+
+        public void Cancel()
+        {
+        }
+    }
+
+    private sealed class TestTabDataGridViewModel : TabDataGridViewModel
+    {
+        private readonly IStatementExecutor _statementExecutor;
+
+        public TestTabDataGridViewModel(
+            ConnectionSettings connectionSettings,
+            StatementResult statementResult,
+            int selectedPage,
+            string name,
+            bool canClose,
+            IServiceProvider serviceProvider,
+            Guid messageTargetId,
+            IStatementExecutor statementExecutor)
+            : base(connectionSettings, statementResult, selectedPage, name, canClose, serviceProvider, messageTargetId)
+        {
+            _statementExecutor = statementExecutor;
+        }
+
+        protected override IStatementExecutor CreateStatementExecutor()
+        {
+            return _statementExecutor;
+        }
+    }
+}

--- a/DataDeveloper.sln
+++ b/DataDeveloper.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataDeveloper", "DataDeveloper\DataDeveloper.csproj", "{19B9B9F2-2D2B-41CB-ABF2-CDA0FC6BE9F5}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DataDeveloper", "DataDeveloper", "{FAF2B864-AE65-460A-BD62-163B1C1838DE}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataDeveloper.Data", "DataDeveloper.Data\DataDeveloper.Data.csproj", "{A4835CC5-C00D-4F16-943F-D57B3A8547CD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataDeveloper.Core", "DataDeveloper.Core\DataDeveloper.Core.csproj", "{C228BF58-BD11-40FB-B356-196CDFE2F5C3}"
@@ -16,8 +14,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataDeveloper.Tests", "DataDeveloper.Tests\DataDeveloper.Tests.csproj", "{2931C0B3-C706-4735-9A54-0A17968DC8EC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataDeveloper.NextGrid", "DataDeveloper.NextGrid\DataDeveloper.NextGrid.csproj", "{D9C60A37-EAAE-4CC0-A20C-7E677A18F804}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Teste", "Teste", "{731F0731-3D84-4B85-AE63-9CECB1B445C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -118,10 +114,5 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{19B9B9F2-2D2B-41CB-ABF2-CDA0FC6BE9F5} = {FAF2B864-AE65-460A-BD62-163B1C1838DE}
-		{A4835CC5-C00D-4F16-943F-D57B3A8547CD} = {FAF2B864-AE65-460A-BD62-163B1C1838DE}
-		{C228BF58-BD11-40FB-B356-196CDFE2F5C3} = {FAF2B864-AE65-460A-BD62-163B1C1838DE}
-		{6575A120-9D75-4C77-A384-A198BC7A4F41} = {FAF2B864-AE65-460A-BD62-163B1C1838DE}
-		{D9C60A37-EAAE-4CC0-A20C-7E677A18F804} = {FAF2B864-AE65-460A-BD62-163B1C1838DE}
 	EndGlobalSection
 EndGlobal

--- a/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
+++ b/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
@@ -52,6 +52,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   encrypt,
                                   trust_server_certificate,
                                   allow_blank_password,
+                                  statement_timeout_seconds,
                                   server,
                                   database_name,
                                   port
@@ -76,6 +77,9 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             connectionSettings.Encrypt = reader.GetBoolean(reader.GetOrdinal("encrypt"));
             connectionSettings.TrustServerCertificate = reader.GetBoolean(reader.GetOrdinal("trust_server_certificate"));
             connectionSettings.AllowBlankPassword = reader.GetBoolean(reader.GetOrdinal("allow_blank_password"));
+            connectionSettings.StatementTimeoutSeconds = reader.IsDBNull(reader.GetOrdinal("statement_timeout_seconds"))
+                ? ConnectionSettings.DefaultStatementTimeoutSeconds
+                : NormalizeStatementTimeout(reader.GetInt32(reader.GetOrdinal("statement_timeout_seconds")));
 
             switch (connectionSettings)
             {
@@ -180,6 +184,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                       encrypt,
                                       trust_server_certificate,
                                       allow_blank_password,
+                                      statement_timeout_seconds,
                                       server,
                                       database_name,
                                       port,
@@ -197,6 +202,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                       $encrypt,
                                       $trustServerCertificate,
                                       $allowBlankPassword,
+                                      $statementTimeoutSeconds,
                                       $server,
                                       $databaseName,
                                       $port,
@@ -215,6 +221,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             command.Parameters.AddWithValue("$encrypt", item.Encrypt ? 1 : 0);
             command.Parameters.AddWithValue("$trustServerCertificate", item.TrustServerCertificate ? 1 : 0);
             command.Parameters.AddWithValue("$allowBlankPassword", item.AllowBlankPassword ? 1 : 0);
+            command.Parameters.AddWithValue("$statementTimeoutSeconds", NormalizeStatementTimeout(item.StatementTimeoutSeconds));
             command.Parameters.AddWithValue("$server", GetServer(item));
             command.Parameters.AddWithValue("$databaseName", GetDatabase(item));
             command.Parameters.AddWithValue("$port", GetPort(item));
@@ -268,6 +275,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   encrypt,
                                   trust_server_certificate,
                                   allow_blank_password,
+                                  statement_timeout_seconds,
                                   server,
                                   database_name,
                                   port,
@@ -285,6 +293,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   $encrypt,
                                   $trustServerCertificate,
                                   $allowBlankPassword,
+                                  $statementTimeoutSeconds,
                                   $server,
                                   $databaseName,
                                   $port,
@@ -300,6 +309,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   encrypt = excluded.encrypt,
                                   trust_server_certificate = excluded.trust_server_certificate,
                                   allow_blank_password = excluded.allow_blank_password,
+                                  statement_timeout_seconds = excluded.statement_timeout_seconds,
                                   server = excluded.server,
                                   database_name = excluded.database_name,
                                   port = excluded.port,
@@ -318,6 +328,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         command.Parameters.AddWithValue("$encrypt", connectionSettings.Encrypt ? 1 : 0);
         command.Parameters.AddWithValue("$trustServerCertificate", connectionSettings.TrustServerCertificate ? 1 : 0);
         command.Parameters.AddWithValue("$allowBlankPassword", connectionSettings.AllowBlankPassword ? 1 : 0);
+        command.Parameters.AddWithValue("$statementTimeoutSeconds", NormalizeStatementTimeout(connectionSettings.StatementTimeoutSeconds));
         command.Parameters.AddWithValue("$server", GetServer(connectionSettings));
         command.Parameters.AddWithValue("$databaseName", GetDatabase(connectionSettings));
         command.Parameters.AddWithValue("$port", GetPort(connectionSettings));
@@ -365,6 +376,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   encrypt integer not null,
                                   trust_server_certificate integer not null,
                                   allow_blank_password integer not null,
+                                  statement_timeout_seconds integer not null default 60,
                                   server text not null,
                                   database_name text not null,
                                   port integer null,
@@ -374,6 +386,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                               """;
         command.ExecuteNonQuery();
         EnsureColumnExists(connection, "sql_server_authentication_mode", "integer not null default 0");
+        EnsureColumnExists(connection, "statement_timeout_seconds", "integer not null default 60");
 
         _isInitialized = true;
     }
@@ -450,6 +463,9 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         connectionSettings is SqlServerConnectionSettings sqlServer
             ? (int)sqlServer.AuthenticationMode
             : (int)SqlServerAuthenticationMode.SqlLogin;
+
+    private static int NormalizeStatementTimeout(int timeoutSeconds) =>
+        timeoutSeconds > 0 ? timeoutSeconds : ConnectionSettings.DefaultStatementTimeoutSeconds;
 
     private static void EnsureColumnExists(SqliteConnection connection, string columnName, string columnDefinition)
     {

--- a/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
+++ b/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
@@ -89,6 +89,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                         : (SqlServerAuthenticationMode)reader.GetInt32(reader.GetOrdinal("sql_server_authentication_mode"));
                     sqlServer.Server = reader.GetString(reader.GetOrdinal("server"));
                     sqlServer.Database = reader.GetString(reader.GetOrdinal("database_name"));
+                    sqlServer.Port = reader.IsDBNull(reader.GetOrdinal("port")) ? 1433 : Convert.ToInt32(reader.GetInt64(reader.GetOrdinal("port")));
                     break;
                 case MySqlConnectionSettings mySql:
                     mySql.Server = reader.GetString(reader.GetOrdinal("server"));
@@ -453,6 +454,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
     private static object GetPort(ConnectionSettings connectionSettings) =>
         connectionSettings switch
         {
+            SqlServerConnectionSettings sqlServer => sqlServer.Port,
             OracleConnectionSettings oracle => oracle.Port,
             PostgresConnectionSettings postgres => postgres.Port,
             MySqlConnectionSettings mySql => (long)mySql.Port,

--- a/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
+++ b/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
@@ -286,7 +286,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
     public bool IsSqLiteConnectionSelected => SelectedConnection?.DatabaseType == DatabaseType.SqLite;
     public bool IsSqlServerConnectionSelected => SelectedConnection?.DatabaseType == DatabaseType.SqlServer;
     public bool IsPortConnectionSelected =>
-        SelectedConnection?.DatabaseType is DatabaseType.MySql or DatabaseType.PostgresSql or DatabaseType.Oracle;
+        SelectedConnection?.DatabaseType is DatabaseType.SqlServer or DatabaseType.MySql or DatabaseType.PostgresSql or DatabaseType.Oracle;
     public bool IsServerConnectionSelected => SelectedConnection?.DatabaseType != DatabaseType.SqLite;
     public bool UsesCredentials => SelectedConnection?.DatabaseType != DatabaseType.SqLite;
     public bool UsesSqlServerAuthenticationMode => SelectedConnection?.DatabaseType == DatabaseType.SqlServer;
@@ -449,6 +449,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Name = "New SQL Server connection",
                 Server = "",
                 Database = "",
+                Port = 1433,
                 User = "",
                 Password = "",
                 Encrypt = true,

--- a/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
+++ b/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
@@ -51,6 +51,7 @@ public sealed class SqlServerAuthenticationOption
 
 public class ConnectionSelectorViewModel : ViewModelBase
 {
+    private static readonly int[] SupportedStatementTimeouts = [15, 30, 60, 120, 240, 480];
     private readonly IConnectionSettingsRepository _connectionSettingsRepository;
     private readonly DatabaseProviderFactoryService _databaseProviderFactoryService;
     private readonly ISecretStore _secretStore;
@@ -78,6 +79,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
             new SqlServerAuthenticationOption("SQL Server Authentication", SqlServerAuthenticationMode.SqlLogin),
             new SqlServerAuthenticationOption("Windows Authentication", SqlServerAuthenticationMode.WindowsIntegrated)
         ];
+        StatementTimeoutOptions = new ObservableCollection<int>(SupportedStatementTimeouts);
         AvailableDatabaseNames = new ReadOnlyObservableCollection<string>(_availableDatabaseNames);
         LoadConnections();
         SelectedConnectionFilter = AvailableConnectionFilters[0];
@@ -232,6 +234,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
     public ReadOnlyObservableCollection<string> AvailableDatabaseNames { get; }
     public IReadOnlyList<ConnectionTypeFilterOption> AvailableConnectionFilters { get; }
     public IReadOnlyList<SqlServerAuthenticationOption> SqlServerAuthenticationModes { get; }
+    public ObservableCollection<int> StatementTimeoutOptions { get; }
 
     private ConnectionSettings? _selectedConnection;
     public ConnectionSettings? SelectedConnection
@@ -253,6 +256,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
             this.RaisePropertyChanged(nameof(UsesSqlServerAuthenticationMode));
             this.RaisePropertyChanged(nameof(UsesCredentialsForSelectedConnection));
             this.RaisePropertyChanged(nameof(SelectedSqlServerAuthenticationOption));
+            this.RaisePropertyChanged(nameof(SelectedStatementTimeoutSeconds));
         }
     }
 
@@ -316,6 +320,19 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 return;
 
             sqlServer.AuthenticationMode = value.Value;
+        }
+    }
+
+    public int SelectedStatementTimeoutSeconds
+    {
+        get => NormalizeStatementTimeout(SelectedConnection?.StatementTimeoutSeconds);
+        set
+        {
+            if (SelectedConnection is null)
+                return;
+
+            SelectedConnection.StatementTimeoutSeconds = NormalizeStatementTimeout(value);
+            this.RaisePropertyChanged();
         }
     }
     
@@ -436,6 +453,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Password = "",
                 Encrypt = true,
                 TrustServerCertificate = false,
+                StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
                 DatabaseType = DatabaseType.SqlServer
             },
             DatabaseType.Oracle => new OracleConnectionSettings
@@ -449,6 +467,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Port = 1521,
                 Encrypt = false,
                 TrustServerCertificate = false,
+                StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
                 DatabaseType = DatabaseType.Oracle
             },
             DatabaseType.PostgresSql => new PostgresConnectionSettings
@@ -462,6 +481,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Port = 5432,
                 Encrypt = false,
                 TrustServerCertificate = false,
+                StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
                 DatabaseType = DatabaseType.PostgresSql
             },
             DatabaseType.MySql => new MySqlConnectionSettings
@@ -475,6 +495,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Port = 3306,
                 Encrypt = false,
                 TrustServerCertificate = true,
+                StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
                 DatabaseType = DatabaseType.MySql
             },
             DatabaseType.SqLite => new SqLiteConnectionSettings
@@ -486,6 +507,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Password = "",
                 Encrypt = false,
                 TrustServerCertificate = false,
+                StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
                 DatabaseType = DatabaseType.SqLite
             },
             _ => throw new NotSupportedException($"Database type {databaseType} is not supported.")
@@ -502,6 +524,16 @@ public class ConnectionSelectorViewModel : ViewModelBase
         sqlServer.Password = string.Empty;
         sqlServer.IsPasswordLoaded = true;
         sqlServer.LoadedPasswordSnapshot = string.Empty;
+    }
+
+    private static int NormalizeStatementTimeout(int? timeoutSeconds)
+    {
+        if (timeoutSeconds is null)
+            return ConnectionSettings.DefaultStatementTimeoutSeconds;
+
+        return SupportedStatementTimeouts.Contains(timeoutSeconds.Value)
+            ? timeoutSeconds.Value
+            : ConnectionSettings.DefaultStatementTimeoutSeconds;
     }
 
     private async Task SelectSqLiteFileAsync()

--- a/DataDeveloper/ViewModels/TabDataGridViewModel.cs
+++ b/DataDeveloper/ViewModels/TabDataGridViewModel.cs
@@ -514,7 +514,15 @@ public class TabDataGridViewModel : BaseTabContent
         }
         catch (Exception ex)
         {
-            await transaction.RollbackAsync();
+            try
+            {
+                await transaction.RollbackAsync();
+            }
+            catch
+            {
+                // Some providers auto-complete the transaction after a command failure.
+            }
+
             PublishSubmitFailureMessage(ex);
         }
         finally
@@ -526,9 +534,10 @@ public class TabDataGridViewModel : BaseTabContent
     private async Task RefreshDataAsync()
     {
         await StatementResult.CloseDataReader();
-        var statementExecutor = ConnectionSettings.GetStatementExecutor();
+        var statementExecutor = CreateStatementExecutor();
         var refreshedResult = (await statementExecutor.ExecuteStatement(
                 StatementResult.Statement,
+                StatementResult.Parameters,
                 commandTimeoutSeconds: _commandTimeoutSeconds))
             .FirstOrDefault(result => result.HasResultSet);
         if (refreshedResult is null)
@@ -537,6 +546,11 @@ public class TabDataGridViewModel : BaseTabContent
         StatementResult = refreshedResult;
         IsClosed = false;
         await LoadData();
+    }
+
+    protected virtual IStatementExecutor CreateStatementExecutor()
+    {
+        return ConnectionSettings.GetStatementExecutor();
     }
 
     private void PublishSubmitMessage(int insertedCount, int updatedCount, int deletedCount)
@@ -729,6 +743,7 @@ public class TabDataGridViewModel : BaseTabContent
     [Reactive] public string? EditabilityReason { get; private set; }
     [Reactive] public bool HasPendingChanges { get; private set; }
     [Reactive] public int SelectedRowIndex { get; set; } = -1;
+    [Reactive] public string GridSelectionStatusText { get; set; } = "Cell=nothing";
     [Reactive] public TimeSpan TimeElapsed { get; set; }
     [Reactive] public bool IsClosed { get; set; }
     [Reactive] public int RowNumber { get; set; }

--- a/DataDeveloper/ViewModels/TabDataGridViewModel.cs
+++ b/DataDeveloper/ViewModels/TabDataGridViewModel.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using DataDeveloper.Data;
@@ -17,6 +18,7 @@ using DataDeveloper.Enums;
 using DataDeveloper.EventAggregators;
 using DataDeveloper.Interfaces;
 using DataDeveloper.Models;
+using DataDeveloper.NextGrid;
 using DynamicData;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
@@ -26,10 +28,19 @@ namespace DataDeveloper.ViewModels;
 
 public class TabDataGridViewModel : BaseTabContent
 {
+    // Reads from the DataReader off the UI thread before dispatching rows for visual append.
+    private const int UiBatchSize = 200;
+    // Limits how many rows are appended per UI frame to keep the interface responsive.
+    private const int UiFrameBatchSize = 80;
+    // Avoids rebinding the row counter label on every small append.
+    private const int RowNumberUiUpdateBatchSize = 1000;
     private readonly IEventAggregatorService _eventAggregatorService;
     private readonly Guid _messageTargetId;
     private readonly Action? _focusMessageTab;
+    private readonly Action<bool, string>? _reportExecutionStatus;
+    private readonly int? _commandTimeoutSeconds;
     private readonly List<PendingDeletedGridRow> _pendingDeletedRows = [];
+    private CancellationTokenSource? _loadCancellationTokenSource;
 
     public TabDataGridViewModel(
         IConnectionSettings connectionSettings,
@@ -39,42 +50,51 @@ public class TabDataGridViewModel : BaseTabContent
         bool canClose,
         IServiceProvider serviceProvider,
         Guid messageTargetId,
-        Action? focusMessageTab = null) 
+        int? commandTimeoutSeconds = null,
+        Action? focusMessageTab = null,
+        Action<bool, string>? reportExecutionStatus = null) 
         : base(TabType.DataGrid, name, canClose, serviceProvider)
     {
         _eventAggregatorService = ServiceProvider.GetRequiredService<IEventAggregatorService>();
         _messageTargetId = messageTargetId;
         _focusMessageTab = focusMessageTab;
+        _reportExecutionStatus = reportExecutionStatus;
+        _commandTimeoutSeconds = commandTimeoutSeconds;
         ConnectionSettings = connectionSettings;
         StatementResult = statementResult;
 
         SelectedPage = selectedPage;
         LoadNextPageCommand = ReactiveCommand.CreateFromTask(() => LoadNextPage(SelectedPage)
             , outputScheduler: RxApp.MainThreadScheduler
-            , canExecute: this.WhenAnyValue(x => x.IsClosed).Select(_ => _ is false));
+            , canExecute: this.WhenAnyValue(vm => vm.CanLoadMore));
         LoadAllRecordsCommand = ReactiveCommand.CreateFromTask(() => LoadNextPage()
             , outputScheduler: RxApp.MainThreadScheduler
-            , canExecute: this.WhenAnyValue(x => x.IsClosed).Select(_ => _ is false));
+            , canExecute: this.WhenAnyValue(vm => vm.CanLoadMore));
         DiscardChangesCommand = ReactiveCommand.Create(
             DiscardChanges,
-            this.WhenAnyValue(vm => vm.HasPendingChanges, vm => vm.IsBusy, (hasPendingChanges, isBusy) => hasPendingChanges && !isBusy));
+            this.WhenAnyValue(vm => vm.CanDiscardChanges));
         AddRowCommand = ReactiveCommand.Create(
             AddRow,
-            this.WhenAnyValue(vm => vm.IsEditableResult, vm => vm.IsBusy, (isEditableResult, isBusy) => isEditableResult && !isBusy));
+            this.WhenAnyValue(vm => vm.CanAddRow));
         DeleteRowCommand = ReactiveCommand.Create(
             DeleteSelectedRow,
-            this.WhenAnyValue(vm => vm.IsEditableResult, vm => vm.SelectedRowIndex, vm => vm.IsBusy,
-                (isEditableResult, selectedRowIndex, isBusy) => isEditableResult && selectedRowIndex >= 0 && !isBusy));
+            this.WhenAnyValue(vm => vm.CanDeleteRow));
         SubmitChangesCommand = ReactiveCommand.CreateFromTask(
             SubmitChangesAsync,
-            this.WhenAnyValue(vm => vm.IsEditableResult, vm => vm.HasPendingChanges, vm => vm.HasValidationErrors, vm => vm.IsBusy,
-                (isEditableResult, hasPendingChanges, hasValidationErrors, isBusy) =>
-                    isEditableResult && hasPendingChanges && !hasValidationErrors && !isBusy));
+            this.WhenAnyValue(vm => vm.CanSubmitChanges));
         this.WhenAnyValue(vm => vm.IsEditableResult).Subscribe(_ =>
         {
             this.RaisePropertyChanged(nameof(EditabilityStatusText));
             this.RaisePropertyChanged(nameof(ShowReadOnlyReason));
         });
+        this.WhenAnyValue(
+                vm => vm.IsClosed,
+                vm => vm.IsBusy,
+                vm => vm.IsEditorOperationInProgress,
+                vm => vm.IsEditableResult,
+                vm => vm.HasPendingChanges,
+                vm => vm.SelectedRowIndex)
+            .Subscribe(_ => RaiseActionAvailabilityProperties());
     }
 
     public async Task CloseDataReader()
@@ -82,8 +102,16 @@ public class TabDataGridViewModel : BaseTabContent
         if (IsClosed)
             return;
 
+        _loadCancellationTokenSource?.Cancel();
+        StatementResult.CancelExecution();
         await StatementResult.CloseDataReader();
         await Dispatcher.UIThread.InvokeAsync(() => this.IsClosed = true);
+    }
+
+    public async Task CancelLoadingAsync()
+    {
+        _loadCancellationTokenSource?.Cancel();
+        await Task.CompletedTask;
     }
 
     public async Task LoadData()
@@ -118,7 +146,7 @@ public class TabDataGridViewModel : BaseTabContent
         Headers.Add(columns);
         await ResolveEditabilityAsync(dataReader, columns.Select(column => column.Name).ToList());
         
-        await LoadNextPage(SelectedPage);
+        await LoadNextPage(SelectedPage, showExecutionStatus: false);
         
     }
 
@@ -130,39 +158,120 @@ public class TabDataGridViewModel : BaseTabContent
         return typeof(Nullable<>).MakeGenericType(fieldType);
     }
 
-    private async Task LoadNextPage(int itemsPerPage = 0)
+    private async Task LoadNextPage(int itemsPerPage = 0, bool showExecutionStatus = true)
     {
         var dataReader = StatementResult.DataReader;
         if (dataReader is null)
             return;
 
         var countRecords = 0;
-        StatementResult.Watcher.Start();
-        this.IsBusy = true;
-        await Task.Delay(100);
-        var readedUntilEnd = true;
-        while (dataReader.Read())
+        var statusMessage = itemsPerPage > 0
+            ? $"Loading next {itemsPerPage:N0} records..."
+            : "Loading all remaining records...";
+        using var loadCancellationTokenSource = new CancellationTokenSource();
+        _loadCancellationTokenSource = loadCancellationTokenSource;
+        var cancellationToken = loadCancellationTokenSource.Token;
+
+        try
         {
-            RowNumber++;
-            countRecords++;
-            
-            var values = new object[dataReader.FieldCount];
-            dataReader.GetValues(values);
-            this.GridRows.Add(new EditableGridRow(values));
-            
-            if (itemsPerPage > 0 && countRecords == itemsPerPage)
+            if (showExecutionStatus)
             {
-                readedUntilEnd = false;
-                break;
+                _reportExecutionStatus?.Invoke(true, statusMessage);
+                _eventAggregatorService.Publish(new ShowExecutionStatusEvent(true, statusMessage));
+            }
+
+            StatementResult.Watcher.Start();
+            this.IsBusy = true;
+            await Task.Delay(100);
+            var readedUntilEnd = await Task.Run(async () =>
+            {
+                var reachedEnd = true;
+                var pendingRows = new List<EditableGridRow>(Math.Min(UiBatchSize, itemsPerPage > 0 ? itemsPerPage : UiBatchSize));
+
+                while (!cancellationToken.IsCancellationRequested && dataReader.Read())
+                {
+                    countRecords++;
+
+                    var values = new object[dataReader.FieldCount];
+                    dataReader.GetValues(values);
+                    pendingRows.Add(new EditableGridRow(values));
+
+                    if (pendingRows.Count >= UiBatchSize)
+                        await AppendRowsAsync(pendingRows).ConfigureAwait(false);
+
+                    if (itemsPerPage > 0 && countRecords == itemsPerPage)
+                    {
+                        reachedEnd = false;
+                        break;
+                    }
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await AppendRowsAsync(pendingRows, forceCounterUpdate: true).ConfigureAwait(false);
+                return reachedEnd;
+            }, cancellationToken).ConfigureAwait(false);
+
+            if (readedUntilEnd)
+                await this.CloseDataReader().ConfigureAwait(false);
+            StatementResult.Watcher.Stop();
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                this.TimeElapsed = StatementResult.Watcher.Elapsed;
+                ValidateAllRows();
+            });
+        }
+        catch (OperationCanceledException)
+        {
+            StatementResult.Watcher.Stop();
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                TimeElapsed = StatementResult.Watcher.Elapsed;
+                RowNumber = GridRows.Count;
+            });
+
+            _eventAggregatorService.Publish(new ShowResultMessageEvent(
+                _messageTargetId,
+                $"{Name}: loading cancelled after {GridRows.Count:N0} row(s)."));
+        }
+        finally
+        {
+            if (ReferenceEquals(_loadCancellationTokenSource, loadCancellationTokenSource))
+                _loadCancellationTokenSource = null;
+
+            await Dispatcher.UIThread.InvokeAsync(() => this.IsBusy = false);
+            if (showExecutionStatus)
+            {
+                await Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    _reportExecutionStatus?.Invoke(false, string.Empty);
+                    _eventAggregatorService.Publish(new ShowExecutionStatusEvent(false, string.Empty));
+                });
             }
         }
+    }
 
-        if (readedUntilEnd)
-            await this.CloseDataReader();
-        StatementResult.Watcher.Stop();
-        this.TimeElapsed = StatementResult.Watcher.Elapsed;
-        this.IsBusy = false;
-        ValidateAllRows();
+    private async Task AppendRowsAsync(List<EditableGridRow> pendingRows, bool forceCounterUpdate = false)
+    {
+        if (pendingRows.Count == 0)
+            return;
+
+        var rowsToAppend = pendingRows.ToArray();
+        pendingRows.Clear();
+
+        for (var index = 0; index < rowsToAppend.Length; index += UiFrameBatchSize)
+        {
+            var chunk = rowsToAppend.Skip(index).Take(UiFrameBatchSize).ToArray();
+            var isFinalChunk = index + UiFrameBatchSize >= rowsToAppend.Length;
+
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                GridRows.AddRange(chunk);
+
+                var loadedRowCount = GridRows.Count;
+                if ((forceCounterUpdate && isFinalChunk) || loadedRowCount - RowNumber >= RowNumberUiUpdateBatchSize)
+                    RowNumber = loadedRowCount;
+            }, DispatcherPriority.Background);
+        }
     }
 
     private async Task ResolveEditabilityAsync(DbDataReader dataReader, IReadOnlyCollection<string> resultColumns)
@@ -301,6 +410,7 @@ public class TabDataGridViewModel : BaseTabContent
         this.RaisePropertyChanged(nameof(PendingDeleteCount));
         this.RaisePropertyChanged(nameof(PendingChangesSummary));
         this.RaisePropertyChanged(nameof(ShowPendingChangesSummary));
+        RaiseActionAvailabilityProperties();
     }
 
     public void NotifyCellEdited(int rowIndex)
@@ -417,7 +527,10 @@ public class TabDataGridViewModel : BaseTabContent
     {
         await StatementResult.CloseDataReader();
         var statementExecutor = ConnectionSettings.GetStatementExecutor();
-        var refreshedResult = (await statementExecutor.ExecuteStatement(StatementResult.Statement)).FirstOrDefault(result => result.HasResultSet);
+        var refreshedResult = (await statementExecutor.ExecuteStatement(
+                StatementResult.Statement,
+                commandTimeoutSeconds: _commandTimeoutSeconds))
+            .FirstOrDefault(result => result.HasResultSet);
         if (refreshedResult is null)
             return;
 
@@ -487,6 +600,16 @@ public class TabDataGridViewModel : BaseTabContent
 
     public bool ShowReadOnlyReason => !IsEditableResult;
 
+    public bool CanLoadMore => !IsClosed && !IsBusy && !IsEditorOperationInProgress;
+
+    public bool CanDiscardChanges => HasPendingChanges && !IsBusy && !IsEditorOperationInProgress;
+
+    public bool CanAddRow => IsEditableResult && !IsBusy && !IsEditorOperationInProgress;
+
+    public bool CanDeleteRow => IsEditableResult && SelectedRowIndex >= 0 && !IsBusy && !IsEditorOperationInProgress;
+
+    public bool CanSubmitChanges => IsEditableResult && HasPendingChanges && !HasValidationErrors && !IsBusy && !IsEditorOperationInProgress;
+
     public int PendingInsertCount => GridRows.OfType<EditableGridRow>().Count(row => row.State == EditableGridRowState.New);
 
     public int PendingUpdateCount => GridRows.OfType<EditableGridRow>().Count(row => row.State == EditableGridRowState.Modified);
@@ -519,6 +642,15 @@ public class TabDataGridViewModel : BaseTabContent
 
             return string.Join(", ", parts);
         }
+    }
+
+    private void RaiseActionAvailabilityProperties()
+    {
+        this.RaisePropertyChanged(nameof(CanLoadMore));
+        this.RaisePropertyChanged(nameof(CanDiscardChanges));
+        this.RaisePropertyChanged(nameof(CanAddRow));
+        this.RaisePropertyChanged(nameof(CanDeleteRow));
+        this.RaisePropertyChanged(nameof(CanSubmitChanges));
     }
 
     private void ValidateAllRows()
@@ -593,6 +725,7 @@ public class TabDataGridViewModel : BaseTabContent
     public StatementResult StatementResult { get; private set; }
     [Reactive] public EditableResultSetMetadata? EditableMetadata { get; private set; }
     [Reactive] public bool IsEditableResult { get; private set; }
+    [Reactive] public bool IsEditorOperationInProgress { get; set; }
     [Reactive] public string? EditabilityReason { get; private set; }
     [Reactive] public bool HasPendingChanges { get; private set; }
     [Reactive] public int SelectedRowIndex { get; set; } = -1;
@@ -603,7 +736,7 @@ public class TabDataGridViewModel : BaseTabContent
     public ObservableCollection<ColumnHeader> Headers { get; } = new();
     public ObservableCollection<string> GridHeaders { get; } = new();
     public ObservableCollection<Type> GridColumnTypes { get; } = new();
-    public ObservableCollection<IReadOnlyList<object?>> GridRows { get; } = new();
+    public BulkObservableCollection<IReadOnlyList<object?>> GridRows { get; } = new();
     public ObservableCollection<int> ReadOnlyColumnIndexes { get; } = new();
     public ObservableCollection<int> Pages { get; } = new() { 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, };
     public ReactiveCommand<Unit, Unit> LoadNextPageCommand { get; }

--- a/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
+++ b/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
@@ -25,6 +25,7 @@ namespace DataDeveloper.ViewModels;
 
 public class TabQueryEditorViewModel : BaseTabContent
 {
+    private static readonly HashSet<int> SupportedRunTimeouts = [15, 30, 60, 120, 240, 480];
     private readonly IEventAggregatorService _eventAggregatorService;
     private readonly Dictionary<string, int> _cachePages = new();
     private IStatementExecutor? _activeStatementExecutor;
@@ -39,6 +40,7 @@ public class TabQueryEditorViewModel : BaseTabContent
         
         ConnectionSettings = connectionSettings;
         File = file;
+        SelectedRunTimeoutSeconds = NormalizeRunTimeout(connectionSettings.StatementTimeoutSeconds);
 
         ExecuteCommand = ReactiveCommand.CreateFromTask(ExecuteQuery, outputScheduler: RxApp.MainThreadScheduler);
         StopCommand = ReactiveCommand.CreateFromTask(StopQuery, outputScheduler: RxApp.MainThreadScheduler);
@@ -344,5 +346,12 @@ public class TabQueryEditorViewModel : BaseTabContent
     {
         for (var current = exception; current is not null; current = current.InnerException)
             yield return current;
+    }
+
+    private static int NormalizeRunTimeout(int timeoutSeconds)
+    {
+        return SupportedRunTimeouts.Contains(timeoutSeconds)
+            ? timeoutSeconds
+            : DataDeveloper.Data.Models.ConnectionSettings.DefaultStatementTimeoutSeconds;
     }
 }

--- a/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
+++ b/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
@@ -6,7 +6,9 @@ using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Threading;
 using DataDeveloper.Data;
 using DataDeveloper.Data.Interfaces;
 using DataDeveloper.Data.Services;
@@ -25,6 +27,8 @@ public class TabQueryEditorViewModel : BaseTabContent
 {
     private readonly IEventAggregatorService _eventAggregatorService;
     private readonly Dictionary<string, int> _cachePages = new();
+    private IStatementExecutor? _activeStatementExecutor;
+    private CancellationTokenSource? _queryCancellationTokenSource;
     
     public event EventHandler<int>? ShowResultTool; 
 
@@ -43,6 +47,7 @@ public class TabQueryEditorViewModel : BaseTabContent
 
         Tabs.Add(new TabMessageViewModel("Message", false, filterId: this.Id, this.ServiceProvider));
 
+        this.WhenAnyValue(vm => vm.StatementIsRunning).Subscribe(SetEditorOperationState);
         this.WhenAnyValue(vm => vm.CursorOffSet).Subscribe(_ => ShowCursorData());
         this.WhenAnyValue(vm => vm.CursorLine).Subscribe(_ => ShowCursorData());
         this.WhenAnyValue(vm => vm.CursorColumn).Subscribe(_ => ShowCursorData());
@@ -87,12 +92,16 @@ public class TabQueryEditorViewModel : BaseTabContent
     [Reactive] public double ResultsHeaderHeight { get; set; }
     [Reactive] public bool TextWasChanged { get; set; }
     [Reactive] public bool StatementIsRunning { get; set; }
+    [Reactive] public bool IsExecutionStatusVisible { get; set; }
+    [Reactive] public string ExecutionStatusMessage { get; set; } = string.Empty;
     [Reactive] public bool ResultIsMinimized { get; set; } = true;
     [Reactive] public int SelectedTabIndex { get; set; }
+    [Reactive] public int SelectedRunTimeoutSeconds { get; set; } = 60;
     public bool HasDetectedParameters => ParameterValues.Count > 0;
     
     public ObservableCollection<BaseTabContent> Tabs { get; } = new();
     public ObservableCollection<QueryParameterValue> ParameterValues { get; } = new();
+    public ObservableCollection<int> RunTimeoutOptions { get; } = new() { 15, 30, 60, 120, 240, 480 };
     public ReactiveCommand<Unit, Unit> ExecuteCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
     public ReactiveCommand<BaseTabContent, Unit> CloseTabResultCommand { get; }
@@ -100,31 +109,34 @@ public class TabQueryEditorViewModel : BaseTabContent
     
     private async Task StopQuery()
     {
-        await Task.Delay(100);
-        try
-        {
+        ExecutionStatusMessage = "Cancelling...";
 
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex);
-            throw;
-        }
-        finally
-        {
-            this.StatementIsRunning = false;
-        }
+        _queryCancellationTokenSource?.Cancel();
+        _activeStatementExecutor?.Cancel();
+
+        var activeLoads = Tabs
+            .OfType<TabDataGridViewModel>()
+            .Where(tab => tab.IsBusy)
+            .ToList();
+
+        foreach (var activeLoad in activeLoads)
+            await activeLoad.CancelLoadingAsync();
     }
 
     private async Task ExecuteQuery()
     {
+        using var queryCancellationTokenSource = new CancellationTokenSource();
+        _queryCancellationTokenSource = queryCancellationTokenSource;
         this.StatementIsRunning = true;
+        IsExecutionStatusVisible = true;
+        ExecutionStatusMessage = "Executing query...";
         _eventAggregatorService.Publish(new ShowExecutionStatusEvent(true, "Executing query..."));
         await Task.Delay(100);
 
         try
         {
             var statementExecutor = ConnectionSettings.GetStatementExecutor();
+            _activeStatementExecutor = statementExecutor;
             var previousResultTabs = Tabs.OfType<TabDataGridViewModel>().ToList();
             var cleanupWatcher = Stopwatch.StartNew();
             var statementToExecute = SelectedStatementLength > 0 ? SelectedStatement : SqlStatement;
@@ -132,6 +144,8 @@ public class TabQueryEditorViewModel : BaseTabContent
 
             if (previousResultTabs.Count > 0)
             {
+                IsExecutionStatusVisible = true;
+                ExecutionStatusMessage = "Closing previous result set...";
                 _eventAggregatorService.Publish(new ShowExecutionStatusEvent(true, "Closing previous result set..."));
                 await Task.Delay(100);
                 await Task.WhenAll(
@@ -145,7 +159,15 @@ public class TabQueryEditorViewModel : BaseTabContent
             foreach (var previousTab in previousResultTabs)
                 Tabs.Remove(previousTab);
 
-            var statementResults = (await statementExecutor.ExecuteStatement(statementToExecute, parameterValues)).ToList();
+            IsExecutionStatusVisible = true;
+            ExecutionStatusMessage = "Executing query...";
+            _eventAggregatorService.Publish(new ShowExecutionStatusEvent(true, "Executing query..."));
+
+            var statementResults = (await statementExecutor.ExecuteStatement(
+                statementToExecute,
+                parameterValues,
+                SelectedRunTimeoutSeconds,
+                queryCancellationTokenSource.Token)).ToList();
             var shouldRefreshSchema = statementResults.Any(result => StatementExecutionClassifier.RequiresSchemaRefresh(result.Statement));
 
             if (statementResults.Any())
@@ -171,6 +193,8 @@ public class TabQueryEditorViewModel : BaseTabContent
                     if (hasDataReader)
                     {
                         index++;
+                        IsExecutionStatusVisible = true;
+                        ExecutionStatusMessage = "Loading first rows...";
                         _eventAggregatorService.Publish(new ShowExecutionStatusEvent(true, "Loading first rows..."));
                         await Task.Delay(100);
                         
@@ -182,11 +206,22 @@ public class TabQueryEditorViewModel : BaseTabContent
                             true,
                             this.ServiceProvider,
                             this.Id,
+                            SelectedRunTimeoutSeconds,
                             () =>
                             {
-                                SelectedTabIndex = 0;
-                                ShowResultTool?.Invoke(this, SelectedTabIndex);
+                                Dispatcher.UIThread.Post(() =>
+                                {
+                                    SelectedTabIndex = 0;
+                                    ShowResultTool?.Invoke(this, SelectedTabIndex);
+                                });
+                            },
+                            (isVisible, message) =>
+                            {
+                                StatementIsRunning = isVisible;
+                                IsExecutionStatusVisible = isVisible;
+                                ExecutionStatusMessage = message;
                             });
+                        tabResult.IsEditorOperationInProgress = StatementIsRunning;
                         tabResult.WhenAnyValue(vm => vm.SelectedPage).Subscribe(page => _cachePages[statementResult.Statement] = page);
                         
                         Tabs.Add(tabResult);
@@ -213,6 +248,18 @@ public class TabQueryEditorViewModel : BaseTabContent
                 _eventAggregatorService.Publish(new RefreshSchemaExplorerEvent(ConnectionSettings.Id, ddlStatement));
             }
         }
+        catch (OperationCanceledException)
+        {
+            _eventAggregatorService.Publish(new ShowResultMessageEvent(this.Id, "Execution cancelled."));
+            this.SelectedTabIndex = 0;
+        }
+        catch (Exception ex) when (IsTimeoutException(ex))
+        {
+            _eventAggregatorService.Publish(new ShowResultMessageEvent(
+                this.Id,
+                $"Query timed out after {SelectedRunTimeoutSeconds} seconds."));
+            this.SelectedTabIndex = 0;
+        }
         catch (Exception ex)
         {
             _eventAggregatorService.Publish(new ShowResultMessageEvent(this.Id, ex.Message));
@@ -220,8 +267,14 @@ public class TabQueryEditorViewModel : BaseTabContent
         }
         finally
         {
+            if (ReferenceEquals(_queryCancellationTokenSource, queryCancellationTokenSource))
+                _queryCancellationTokenSource = null;
+
+            _activeStatementExecutor = null;
             this.ResultIsMinimized = false;
             this.StatementIsRunning = false;
+            IsExecutionStatusVisible = false;
+            ExecutionStatusMessage = string.Empty;
             _eventAggregatorService.Publish(new ShowExecutionStatusEvent(false, string.Empty));
             this.ShowResultTool?.Invoke(this, this.SelectedTabIndex);
         }
@@ -256,5 +309,40 @@ public class TabQueryEditorViewModel : BaseTabContent
         }
 
         return values;
+    }
+
+    private void SetEditorOperationState(bool isRunning)
+    {
+        foreach (var tab in Tabs.OfType<TabDataGridViewModel>())
+            tab.IsEditorOperationInProgress = isRunning;
+    }
+
+    private static bool IsTimeoutException(Exception exception)
+    {
+        foreach (var current in EnumerateExceptions(exception))
+        {
+            if (current is TimeoutException)
+                return true;
+
+            var message = current.Message;
+            if (message.Contains("Execution Timeout Expired", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("Command Timeout Expired", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("timeout period elapsed", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("query timed out", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("statement timeout", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("canceling statement due to statement timeout", StringComparison.OrdinalIgnoreCase) ||
+                message.Contains("lock wait timeout exceeded", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<Exception> EnumerateExceptions(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+            yield return current;
     }
 }

--- a/DataDeveloper/Views/AppDialogWindow.axaml
+++ b/DataDeveloper/Views/AppDialogWindow.axaml
@@ -51,7 +51,7 @@
                                    LineHeight="21"
                                    TextWrapping="Wrap"
                                    Foreground="#FFD6DAE2"
-                                   TextSelectionEnabled="True" />
+                                   />
                     </ScrollViewer>
                 </StackPanel>
             </Grid>

--- a/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
+++ b/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
@@ -110,13 +110,31 @@
                              IsEnabled="False" />
                 </Grid>
 
-                <TextBlock Text="Server"
-                           IsVisible="{Binding IsServerConnectionSelected}" />
-                <TextBox 
-                    Text="{Binding SelectedConnection.Server, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                    IsEnabled="{Binding IsEditing}"
-                    IsReadOnly="{Binding !IsEditing}"
-                    IsVisible="{Binding IsServerConnectionSelected}" />
+                <Grid RowDefinitions="Auto,Auto"
+                      ColumnDefinitions="3*,1*"
+                      ColumnSpacing="10"
+                      RowSpacing="8"
+                      IsVisible="{Binding IsServerConnectionSelected}">
+                    <TextBlock Grid.Row="0"
+                               Grid.Column="0"
+                               Text="Server" />
+                    <TextBox Grid.Row="1"
+                             Grid.Column="0"
+                             Text="{Binding SelectedConnection.Server, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                             IsEnabled="{Binding IsEditing}"
+                             IsReadOnly="{Binding !IsEditing}" />
+
+                    <TextBlock Grid.Row="0"
+                               Grid.Column="1"
+                               Text="Port"
+                               IsVisible="{Binding IsPortConnectionSelected}" />
+                    <TextBox Grid.Row="1"
+                             Grid.Column="1"
+                             Text="{Binding SelectedConnection.Port, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                             IsEnabled="{Binding IsEditing}"
+                             IsReadOnly="{Binding !IsEditing}"
+                             IsVisible="{Binding IsPortConnectionSelected}" />
+                </Grid>
 
                 <TextBlock Text="{Binding DatabaseLabel}" />
                 <Grid ColumnDefinitions="*,Auto"
@@ -158,15 +176,6 @@
                             Command="{Binding CreateSqLiteFileCommand}" />
                 </StackPanel>
 
-                <Grid RowDefinitions="Auto,Auto"
-                      IsVisible="{Binding IsPortConnectionSelected}">
-                    <TextBlock Grid.Row="0" Text="Port" />
-                    <TextBox Grid.Row="1"
-                             Text="{Binding SelectedConnection.Port, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                             IsEnabled="{Binding IsEditing}"
-                             IsReadOnly="{Binding !IsEditing}" />
-                </Grid>
-
                 <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,*" ColumnSpacing="10" RowSpacing="8"
                       IsVisible="{Binding UsesCredentialsForSelectedConnection}">
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="Username" />
@@ -193,14 +202,6 @@
                     <CheckBox Grid.Column="1"
                               Content="Trust server certificate"
                               IsChecked="{Binding SelectedConnection.TrustServerCertificate, Mode=TwoWay}"
-                              IsEnabled="{Binding IsEditing}" />
-                </Grid>
-
-                <Grid RowDefinitions="Auto,Auto">
-                    <TextBlock Grid.Row="0" Text="Statement timeout" />
-                    <ComboBox Grid.Row="1"
-                              ItemsSource="{Binding StatementTimeoutOptions}"
-                              SelectedItem="{Binding SelectedStatementTimeoutSeconds, Mode=TwoWay}"
                               IsEnabled="{Binding IsEditing}" />
                 </Grid>
 
@@ -245,6 +246,21 @@
                            Foreground="IndianRed"
                            TextWrapping="Wrap"
                            IsVisible="{Binding IsSecureStorageUnavailable}" />
+
+                <Grid ColumnDefinitions="Auto,Auto,*"
+                      ColumnSpacing="8"
+                      VerticalAlignment="Center">
+                    <TextBlock Grid.Column="0"
+                               Text="Default statement timeout"
+                               FontSize="11"
+                               Foreground="DarkGoldenrod"
+                               VerticalAlignment="Center" />
+                    <ComboBox Grid.Column="1"
+                              Width="110"
+                              ItemsSource="{Binding StatementTimeoutOptions}"
+                              SelectedItem="{Binding SelectedStatementTimeoutSeconds, Mode=TwoWay}"
+                              IsEnabled="{Binding IsEditing}" />
+                </Grid>
 
                 <StackPanel Orientation="Horizontal" Spacing="5">
                     <Button  

--- a/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
+++ b/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
@@ -196,6 +196,14 @@
                               IsEnabled="{Binding IsEditing}" />
                 </Grid>
 
+                <Grid RowDefinitions="Auto,Auto">
+                    <TextBlock Grid.Row="0" Text="Statement timeout" />
+                    <ComboBox Grid.Row="1"
+                              ItemsSource="{Binding StatementTimeoutOptions}"
+                              SelectedItem="{Binding SelectedStatementTimeoutSeconds, Mode=TwoWay}"
+                              IsEnabled="{Binding IsEditing}" />
+                </Grid>
+
                 <TextBlock Text="Use 'Trust server certificate' only when the SQL Server certificate is not trusted on this machine."
                            FontSize="11"
                            Foreground="DarkGoldenrod"

--- a/DataDeveloper/Views/MainView.axaml
+++ b/DataDeveloper/Views/MainView.axaml
@@ -85,35 +85,17 @@
             </TabControl>
             
         </Grid>
-        <Border Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="3" Background="#2D2D30" Height="24" VerticalAlignment="Bottom">
-            <Grid ColumnDefinitions="*,Auto,20,Auto,20" Margin="8,0">
-                <StackPanel Grid.Column="1"
-                            Orientation="Horizontal"
-                            Spacing="6"
-                            VerticalAlignment="Center"
-                            HorizontalAlignment="Right"
-                            IsVisible="{Binding IsExecutionStatusVisible}">
-                    <TextBlock Text="{Binding ExecutionStatusMessage}"
-                               Foreground="LightGray"
-                               FontSize="11"
-                               VerticalAlignment="Center"
-                               FontFamily="{StaticResource MonospaceFont}"
-                               />
-                    <ProgressBar Width="80"
-                                 Height="8"
-                                 IsIndeterminate="True"
-                                 VerticalAlignment="Center"/>
-                </StackPanel>
-                <TextBlock Grid.Column="3" VerticalAlignment="Center" FontSize="11" FontFamily="{StaticResource MonospaceFont}" HorizontalAlignment="Right">
-                    <Run Text="Cursor -> " Foreground="Gray"/>
-                    <Run Text="Lin:" Foreground="Gray"/>
-                    <Run Text="{Binding CursorLine}" />
-                    <Run Text=" Col:" Foreground="Gray"/>
-                    <Run Text="{Binding CursorColumn}" />
-                    <Run Text=" Offset:" Foreground="Gray"/>
-                    <Run Text="{Binding CursorOffSet}" />
-                </TextBlock>
-            </Grid>
+        <Border Grid.Row="2"
+                Grid.Column="0"
+                Grid.ColumnSpan="3"
+                BorderThickness="0.5,0,0,0"
+                BorderBrush="LightGray"
+                Opacity="0.5"
+                Padding="8,4">
+            <TextBlock Text="DataDeveloper"
+                       FontSize="11"
+                       Foreground="LightGray"
+                       VerticalAlignment="Center" />
         </Border>
     </Grid>    
 </UserControl>

--- a/DataDeveloper/Views/TabDataGridView.axaml
+++ b/DataDeveloper/Views/TabDataGridView.axaml
@@ -26,11 +26,11 @@
                 VerticalAlignment="Center" 
                 ToolTip.Tip="{Binding SelectedPage, StringFormat='Load next {0} records'}"
                 Command="{Binding LoadNextPageCommand}"
-                IsEnabled="{Binding !IsBusy}"
+                IsEnabled="{Binding CanLoadMore}"
                 >
                 <TextBlock 
                     Text="&#xf04e;" FontFamily="{StaticResource FontAwesomeSolid}" 
-                    Foreground="{Binding !IsClosed, Converter={StaticResource BoolToColor}, ConverterParameter='DodgerBlue|Gray'}"
+                    Foreground="{Binding CanLoadMore, Converter={StaticResource BoolToColor}, ConverterParameter='DodgerBlue|Gray'}"
                     />
             </Button>
             <Button Grid.Column="4"
@@ -38,11 +38,11 @@
                 VerticalAlignment="Center" 
                 ToolTip.Tip="Load all records"
                 Command="{Binding LoadAllRecordsCommand}"
-                IsEnabled="{Binding !IsBusy}"
+                IsEnabled="{Binding CanLoadMore}"
                 >
                 <TextBlock 
                     Text="&#xf050;" FontFamily="{StaticResource FontAwesomeSolid}"
-                    Foreground="{Binding !IsClosed, Converter={StaticResource BoolToColor}, ConverterParameter='DodgerBlue|Gray'}"
+                    Foreground="{Binding CanLoadMore, Converter={StaticResource BoolToColor}, ConverterParameter='DodgerBlue|Gray'}"
                     />
             </Button>
             <Border Grid.Column="5" Background="LightGray" Width="0.5" Opacity="0.5" Margin="0,3" />
@@ -50,37 +50,41 @@
                 Background="Transparent"
                 VerticalAlignment="Center"
                 ToolTip.Tip="Discard pending changes"
-                Command="{Binding DiscardChangesCommand}">
+                Command="{Binding DiscardChangesCommand}"
+                IsEnabled="{Binding CanDiscardChanges}">
                 <TextBlock
                     Text="&#xf2ea;" FontFamily="{StaticResource FontAwesomeSolid}"
-                    Foreground="{Binding HasPendingChanges, Converter={StaticResource BoolToColor}, ConverterParameter='Orange|Gray'}" />
+                    Foreground="{Binding CanDiscardChanges, Converter={StaticResource BoolToColor}, ConverterParameter='Orange|Gray'}" />
             </Button>
             <Button Grid.Column="7"
                 Background="Transparent"
                 VerticalAlignment="Center"
                 ToolTip.Tip="Add row"
-                Command="{Binding AddRowCommand}">
+                Command="{Binding AddRowCommand}"
+                IsEnabled="{Binding CanAddRow}">
                 <TextBlock
                     Text="&#xf067;" FontFamily="{StaticResource FontAwesomeSolid}"
-                    Foreground="{Binding IsEditableResult, Converter={StaticResource BoolToColor}, ConverterParameter='LightGreen|Gray'}" />
+                    Foreground="{Binding CanAddRow, Converter={StaticResource BoolToColor}, ConverterParameter='LightGreen|Gray'}" />
             </Button>
             <Button Grid.Column="8"
                 Background="Transparent"
                 VerticalAlignment="Center"
                 ToolTip.Tip="Delete selected row"
-                Command="{Binding DeleteRowCommand}">
+                Command="{Binding DeleteRowCommand}"
+                IsEnabled="{Binding CanDeleteRow}">
                 <TextBlock
                     Text="&#xf2ed;" FontFamily="{StaticResource FontAwesomeSolid}"
-                    Foreground="{Binding IsEditableResult, Converter={StaticResource BoolToColor}, ConverterParameter='Tomato|Gray'}" />
+                    Foreground="{Binding CanDeleteRow, Converter={StaticResource BoolToColor}, ConverterParameter='Tomato|Gray'}" />
             </Button>
             <Button Grid.Column="9"
                 Background="Transparent"
                 VerticalAlignment="Center"
                 ToolTip.Tip="Submit pending changes"
-                Command="{Binding SubmitChangesCommand}">
+                Command="{Binding SubmitChangesCommand}"
+                IsEnabled="{Binding CanSubmitChanges}">
                 <TextBlock
                     Text="&#xf0c7;" FontFamily="{StaticResource FontAwesomeSolid}"
-                    Foreground="{Binding HasPendingChanges, Converter={StaticResource BoolToColor}, ConverterParameter='DeepSkyBlue|Gray'}" />
+                    Foreground="{Binding CanSubmitChanges, Converter={StaticResource BoolToColor}, ConverterParameter='DeepSkyBlue|Gray'}" />
             </Button>
             <Border Grid.Column="10"
                     BorderThickness="0.5"

--- a/DataDeveloper/Views/TabDataGridView.axaml
+++ b/DataDeveloper/Views/TabDataGridView.axaml
@@ -11,7 +11,7 @@
     </Design.DataContext>
     <Grid RowDefinitions="Auto, Auto, Auto, *">
         <Border Grid.Row="0" Background="LightGray" Height="0.5" Opacity="0.5" />
-        <Grid Grid.Row="1" ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, *, Auto, Auto, Auto, Auto" ColumnSpacing="5" Margin="0,3, 0, 3">
+        <Grid Grid.Row="1" ColumnDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, *, Auto, Auto, Auto, Auto, Auto, Auto" ColumnSpacing="5" Margin="0,3, 0, 3">
             <TextBlock Grid.Column="0" Text="&#xf7a5;" FontFamily="{StaticResource FontAwesomeLight}" FontSize="25" Foreground="LightGray" />
             <TextBlock Grid.Column="1" Text="Rows per page:" FontSize="11" VerticalAlignment="Center" Foreground="LightGray" />
             <ComboBox Grid.Column="2" FontSize="12" FontFamily="{StaticResource MonospaceFont}"
@@ -112,7 +112,14 @@
                            VerticalAlignment="Center"
                            Foreground="#FFC6C6" />
             </Border>
-            <Border Grid.Column="13" BorderThickness="0.5" BorderBrush="LightGray" CornerRadius="3" Margin="0, 3, 0 ,3" Padding="4, 0, 5, 0">
+            <TextBlock Grid.Column="13"
+                       Text="{Binding GridSelectionStatusText}"
+                       FontSize="11"
+                       FontFamily="{StaticResource MonospaceFont}"
+                       VerticalAlignment="Center"
+                       Foreground="LightGray" />
+            <Border Grid.Column="14" Background="LightGray" Width="0.5" Opacity="0.5" Margin="0,3" />
+            <Border Grid.Column="15" BorderThickness="0.5" BorderBrush="LightGray" CornerRadius="3" Margin="0, 3, 0 ,3" Padding="4, 0, 5, 0">
                 <TextBlock 
                     Text="" 
                     FontSize="11" VerticalAlignment="Center" HorizontalAlignment="Right" Foreground="LightGray">
@@ -120,13 +127,13 @@
                     <Run Text="{Binding TimeElapsed, StringFormat=' in {0:c}'}"/>
                 </TextBlock>
             </Border>
-            <Border Grid.Column="14" Background="LightGray" Width="0.5" Opacity="0.5" Margin="0,3" />
-            <TextBlock Grid.Column="15"
+            <Border Grid.Column="16" Background="LightGray" Width="0.5" Opacity="0.5" Margin="0,3" />
+            <TextBlock Grid.Column="17"
                        Text="{Binding EditabilityStatusText}"
                        FontSize="11"
                        VerticalAlignment="Center"
                        Foreground="LightGray" />
-            <TextBlock Grid.Column="16"
+            <TextBlock Grid.Column="18"
                        Text="&#xf05a;"
                        FontFamily="{StaticResource FontAwesomeSolid}"
                        Foreground="#FFD8AE"
@@ -143,6 +150,7 @@
                                   CanEditCells="{Binding IsEditableResult}"
                                   ReadOnlyColumns="{Binding ReadOnlyColumnIndexes}"
                                   SelectedRowIndex="{Binding SelectedRowIndex, Mode=TwoWay}"
+                                  SelectionStatusText="{Binding GridSelectionStatusText, Mode=TwoWay}"
                                   GridFontFamily="{StaticResource MonospaceFont}"
                                   GridFontSize="12"
                                   CellBackground="#2B2B2B"

--- a/DataDeveloper/Views/TabQueryEditorView.axaml
+++ b/DataDeveloper/Views/TabQueryEditorView.axaml
@@ -25,6 +25,18 @@
             <RowDefinition Height="1*" MinHeight="{Binding ResultsHeaderHeight, Mode=OneWay}" />
         </Grid.RowDefinitions>
         <StackPanel x:Name="StackPanelEditor" Grid.Row="0" Margin="4" Background="#3C3F41" Orientation="Horizontal">
+            <TextBlock Text="Statement timeout:"
+                       Margin="0,0,6,0"
+                       VerticalAlignment="Center"
+                       Foreground="LightGray"
+                       FontSize="11" />
+            <ComboBox Width="72"
+                      Margin="0,0,8,0"
+                      SelectedItem="{Binding SelectedRunTimeoutSeconds, Mode=TwoWay}"
+                      ItemsSource="{Binding RunTimeoutOptions}"
+                      VerticalAlignment="Center"
+                      FontSize="11"
+                      FontFamily="{StaticResource MonospaceFont}" />
             <Button Background="Transparent" Command="{Binding ExecuteCommand}" IsEnabled="{Binding !StatementIsRunning}" ToolTip.Tip="F5 - Run the statement" >
                 <TextBlock FontFamily="{StaticResource FontAwesomeSolid}" Text="&#xf04b;" Foreground="{Binding !StatementIsRunning, Converter={StaticResource BoolToColor}, ConverterParameter='Green|Gray'}" Background="Transparent"></TextBlock>
             </Button>
@@ -87,8 +99,42 @@
         </Grid>
         <GridSplitter x:Name="Splitter" Grid.Row="2" Height="5" ResizeDirection="Rows"/>
         <Grid Grid.Row="3" RowDefinitions="Auto,Auto, *">
-            <StackPanel x:Name="StackPanelResult" Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Background="Transparent" Margin="5" Click="ToggleTabs_Click">
+            <Grid x:Name="StackPanelResult" Grid.Row="0" ColumnDefinitions="*,Auto" Margin="4,0">
+                <StackPanel Grid.Column="0"
+                            Orientation="Horizontal"
+                            Spacing="10"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Left"
+                            Margin="5,0">
+                    <TextBlock VerticalAlignment="Center"
+                               FontSize="11"
+                               FontFamily="{StaticResource MonospaceFont}">
+                        <Run Text="Cursor -> " Foreground="Gray"/>
+                        <Run Text="Lin:" Foreground="Gray"/>
+                        <Run Text="{Binding CursorLine}" />
+                        <Run Text=" Col:" Foreground="Gray"/>
+                        <Run Text="{Binding CursorColumn}" />
+                        <Run Text=" Offset:" Foreground="Gray"/>
+                        <Run Text="{Binding CursorOffSet}" />
+                    </TextBlock>
+                    <Border Width="1"
+                            Height="14"
+                            Background="LightGray"
+                            Opacity="0.5"
+                            VerticalAlignment="Center" />
+                    <TextBlock Text="{Binding ExecutionStatusMessage}"
+                               IsVisible="{Binding IsExecutionStatusVisible}"
+                               Foreground="LightGray"
+                               FontSize="11"
+                               VerticalAlignment="Center"
+                               FontFamily="{StaticResource MonospaceFont}" />
+                    <ProgressBar Width="80"
+                                 Height="8"
+                                 IsIndeterminate="True"
+                                 IsVisible="{Binding IsExecutionStatusVisible}"
+                                 VerticalAlignment="Center"/>
+                </StackPanel>
+                <Button Grid.Column="1" Background="Transparent" Margin="5" Click="ToggleTabs_Click">
                     <TextBlock 
                         FontSize="12" 
                         Text="{Binding ResultIsMinimized, Converter={StaticResource BoolToIcon}, ConverterParameter='&#xf077;|&#xf078;'}" 
@@ -96,7 +142,7 @@
                         VerticalAlignment="Center" 
                         />
                 </Button>
-            </StackPanel>
+            </Grid>
             <Border Grid.Row="1" Background="LightGray" Height="0.5" Opacity="0.5" />
             <TabControl Grid.Row="2"  x:Name="Tabs" ItemsSource="{Binding Tabs}" SelectedIndex="{Binding SelectedTabIndex}">
                 <TabControl.ItemTemplate>

--- a/DataDeveloper/Views/TabQueryEditorView.axaml
+++ b/DataDeveloper/Views/TabQueryEditorView.axaml
@@ -44,7 +44,12 @@
                 <TextBlock FontFamily="{StaticResource FontAwesomeSolid}" Text="&#xf04d;" Foreground="{Binding StatementIsRunning, Converter={StaticResource BoolToColor}, ConverterParameter='Firebrick|Gray'}" Background="Transparent"></TextBlock>
             </Button>
         </StackPanel>
-        <Grid Grid.Row="1" ColumnDefinitions="*,Auto">
+        <Grid x:Name="EditorLayoutGrid" Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="0" />
+                <ColumnDefinition Width="0" MinWidth="0" />
+            </Grid.ColumnDefinitions>
             <avaloniaEdit:TextEditor 
                 Grid.Column="0"
                 x:Name="SqlEditor"
@@ -56,27 +61,41 @@
                 Background="#202424"
                 Text="select * from payment"
             />
-            <Border Grid.Column="1"
+            <GridSplitter Grid.Column="1"
+                          Width="5"
+                          ResizeDirection="Columns"
+                          IsVisible="{Binding HasDetectedParameters}" />
+            <Border Grid.Column="2"
                 IsVisible="{Binding HasDetectedParameters}"
                 Background="#2B2B2B"
                 BorderBrush="#4A4A4A"
                 BorderThickness="1,0,0,0"
-                Width="320">
-            <Grid RowDefinitions="Auto,Auto,*">
+                HorizontalAlignment="Stretch">
+            <Grid RowDefinitions="Auto,Auto,*" IsSharedSizeScope="True">
                 <TextBlock Text="Parameters"
                            Margin="10,10,10,6"
                            FontWeight="SemiBold"
                            Foreground="White" />
-                <Grid Grid.Row="1" ColumnDefinitions="120,Auto,*" Margin="10,0,10,6" ColumnSpacing="8">
-                    <TextBlock Grid.Column="0" Text="Name" Foreground="#BBBBBB" FontSize="11" />
-                    <TextBlock Grid.Column="1" Text="Null" Foreground="#BBBBBB" FontSize="11" />
-                    <TextBlock Grid.Column="2" Text="Value" Foreground="#BBBBBB" FontSize="11" />
+                <Grid Grid.Row="1" Margin="10,0,10,6" ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition SharedSizeGroup="colLabel" Width="Auto" />
+                        <ColumnDefinition SharedSizeGroup="colCheckBox" Width="Auto" />
+                        <ColumnDefinition SharedSizeGroup="colValue" Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0" Text="Name" Foreground="#BBBBBB" FontSize="11" VerticalAlignment="Center" />
+                    <TextBlock Grid.Column="1" Text="Send&#10;as Null" Foreground="#BBBBBB" FontSize="11" VerticalAlignment="Center" TextAlignment="Center"/>
+                    <TextBlock Grid.Column="2" Text="Value" Foreground="#BBBBBB" FontSize="11" VerticalAlignment="Center"/>
                 </Grid>
                 <ScrollViewer Grid.Row="2" Margin="10,0,10,10" VerticalScrollBarVisibility="Auto">
                     <ItemsControl ItemsSource="{Binding ParameterValues}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Grid ColumnDefinitions="120,Auto,*" ColumnSpacing="8" Margin="0,0,0,6">
+                                <Grid ColumnSpacing="8" Margin="0,0,0,6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition SharedSizeGroup="colLabel" Width="Auto" />
+                                        <ColumnDefinition SharedSizeGroup="colCheckBox" Width="Auto" />
+                                        <ColumnDefinition SharedSizeGroup="colValue" Width="Auto" />
+                                    </Grid.ColumnDefinitions>
                                     <TextBlock Grid.Column="0"
                                                Text="{Binding Name}"
                                                VerticalAlignment="Center"
@@ -88,6 +107,8 @@
                                     <TextBox Grid.Column="2"
                                              Text="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                              IsEnabled="{Binding !IsNull}"
+                                             MinWidth="120"
+                                             HorizontalAlignment="Stretch"
                                              Watermark="null" />
                                 </Grid>
                             </DataTemplate>

--- a/DataDeveloper/Views/TabQueryEditorView.axaml.cs
+++ b/DataDeveloper/Views/TabQueryEditorView.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reactive;
 using System.Threading.Tasks;
 using Avalonia.Controls;
@@ -22,7 +23,10 @@ namespace DataDeveloper.Views;
 public partial class TabQueryEditorView : UserControl
 {
     private GridLength _previousTabHeight = new(200);
+    private GridLength _previousParametersPanelWidth = new(320);
     private const double FallbackExpandedResultsHeight = 200;
+    private const double DefaultParametersPanelWidth = 320;
+    private const double MinimumParametersPanelWidth = 220;
     private TabQueryEditorViewModel? _viewModel;
     private readonly TabTemplateSelector? _templateSelector;
     private readonly CompletionInteractionState _completionInteractionState = new();
@@ -50,6 +54,7 @@ public partial class TabQueryEditorView : UserControl
         {
             _viewModel.ShowResultTool -= ViewModelOnShowResultTool;
             _viewModel.Tabs.CollectionChanged -= TabsOnCollectionChanged;
+            _viewModel.PropertyChanged -= ViewModelOnPropertyChanged;
         }
 
         _viewModel = DataContext as TabQueryEditorViewModel;
@@ -62,6 +67,8 @@ public partial class TabQueryEditorView : UserControl
         SqlEditor.Bind(TextEditorBindingHelper.BindableCaretOffsetProperty, new Binding(nameof(TabQueryEditorViewModel.CursorOffSet)));
         SqlEditor.Bind(TextEditorBindingHelper.BindableCaretLineProperty, new Binding(nameof(TabQueryEditorViewModel.CursorLine)));
         SqlEditor.Bind(TextEditorBindingHelper.BindableCaretColumnProperty, new Binding(nameof(TabQueryEditorViewModel.CursorColumn)));
+        _viewModel.PropertyChanged += ViewModelOnPropertyChanged;
+        ApplyParametersPanelState();
     }
     
     private void OnLoaded(object? sender, RoutedEventArgs e)
@@ -76,6 +83,7 @@ public partial class TabQueryEditorView : UserControl
         ConfigureEditorContextMenu();
         UpdateActiveEditorState();
         ApplyResultsPanelState();
+        ApplyParametersPanelState();
     }
 
     private void OnUnloaded(object? sender, RoutedEventArgs e)
@@ -99,6 +107,12 @@ public partial class TabQueryEditorView : UserControl
     private void ViewModelOnShowResultTool(object? sender, int e)
     {
         ApplyResultsPanelState();
+    }
+
+    private void ViewModelOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TabQueryEditorViewModel.HasDetectedParameters))
+            ApplyParametersPanelState();
     }
 
     private void ToggleTabs_Click(object? sender, RoutedEventArgs e)
@@ -144,6 +158,34 @@ public partial class TabQueryEditorView : UserControl
     private static bool IsExpandedHeightCandidate(GridLength length, double collapsedHeight)
     {
         return !length.IsAbsolute || length.Value > collapsedHeight + 1;
+    }
+
+    private void ApplyParametersPanelState()
+    {
+        var splitterColumn = EditorLayoutGrid.ColumnDefinitions[1];
+        var panelColumn = EditorLayoutGrid.ColumnDefinitions[2];
+
+        if (_viewModel?.HasDetectedParameters == true)
+        {
+            splitterColumn.Width = new GridLength(5);
+            panelColumn.MinWidth = MinimumParametersPanelWidth;
+            panelColumn.Width = IsParametersPanelWidthCandidate(_previousParametersPanelWidth)
+                ? _previousParametersPanelWidth
+                : new GridLength(DefaultParametersPanelWidth);
+            return;
+        }
+
+        if (panelColumn.ActualWidth > MinimumParametersPanelWidth)
+            _previousParametersPanelWidth = new GridLength(panelColumn.ActualWidth);
+
+        splitterColumn.Width = new GridLength(0);
+        panelColumn.MinWidth = 0;
+        panelColumn.Width = new GridLength(0);
+    }
+
+    private static bool IsParametersPanelWidthCandidate(GridLength width)
+    {
+        return !width.IsAbsolute || width.Value >= MinimumParametersPanelWidth;
     }
 
     private async void TextAreaOnTextEntered(object? sender, TextInputEventArgs e)

--- a/TODOS.md
+++ b/TODOS.md
@@ -22,7 +22,7 @@
 
 # FIXs
 
-- [ ] Fazer o progressbar de load ser exibido a cada execução proxima pagina ou de listar até o final
-- [ ] Colocar um botão de stop para interromper o load de pagina de registros
-- [ ] Validar o botão do stop da query para rodar assincrono e poder ser clicado
+- [x] Fazer o progressbar de load ser exibido a cada execução proxima pagina ou de listar até o final
+- [x] Colocar um botão de stop para interromper o load de pagina de registros
+- [x] Validar o botão do stop da query para rodar assincrono e poder ser clicado
 - [ ] Trocar fontAwesome por material-icons


### PR DESCRIPTION
## Summary
- move execution status and progress into the query editor tab and restore a simple application footer
- make result loading more responsive with UI batching, bulk row updates, and NextGrid presenter optimizations
- add functional stop/cancel behavior and per-tab statement timeout handling across supported providers
- disable load/edit actions while editor execution is in progress and align button icon states with availability
- update repository provider guidance to require support across all supported providers

## Validation
- `dotnet build DataDeveloper.sln`
- manual validation: slow query + `Stop`
- manual validation: large `Load all` + `Stop`
- manual validation: timeout with `15s`

## Notes
- includes open workspace changes related to this flow, including `TODOS.md`, `AppDialogWindow.axaml`, and solution cleanup in `DataDeveloper.sln`
- provider cancellation/timeout handling is implemented on generic `DbCommand`/`DbDataReader` paths, with broader exception detection across supported providers
