### PR TITLE
Add configurable DML transaction mode

### DIFF
--- a/DataDeveloper.Data/Enums/DmlTransactionMode.cs
+++ b/DataDeveloper.Data/Enums/DmlTransactionMode.cs
@@ -1,0 +1,7 @@
+namespace DataDeveloper.Data.Enums;
+
+public enum DmlTransactionMode
+{
+    AutoCommit = 0,
+    ManualCommitRollback = 1
+}

--- a/DataDeveloper.Data/Interfaces/IConnectionSettings.cs
+++ b/DataDeveloper.Data/Interfaces/IConnectionSettings.cs
@@ -12,5 +12,6 @@ public interface IConnectionSettings
     bool TrustServerCertificate { get; set; }
     bool AllowBlankPassword { get; set; }
     int StatementTimeoutSeconds { get; set; }
+    DmlTransactionMode DmlTransactionMode { get; set; }
     DatabaseType DatabaseType { get; set; }
 }

--- a/DataDeveloper.Data/Interfaces/IStatementExecutor.cs
+++ b/DataDeveloper.Data/Interfaces/IStatementExecutor.cs
@@ -15,6 +15,11 @@ public interface IStatementExecutor
         int? commandTimeoutSeconds = null,
         CancellationToken cancellationToken = default);
 
+    Task<int> ExecuteCommandInTransaction(
+        EditableResultSetCommand command,
+        int? commandTimeoutSeconds = null,
+        CancellationToken cancellationToken = default);
+
     Task CommitTransaction(CancellationToken cancellationToken = default);
 
     Task RollbackTransaction(CancellationToken cancellationToken = default);

--- a/DataDeveloper.Data/JsonConverters/ConnectionSettingsConverter.cs
+++ b/DataDeveloper.Data/JsonConverters/ConnectionSettingsConverter.cs
@@ -30,6 +30,10 @@ public class ConnectionSettingsConverter : JsonConverter<ConnectionSettings>
             DatabaseType.SqLite => (ConnectionSettings?)JsonSerializer.Deserialize<SqLiteConnectionSettings>(json, options),
             _ => throw new NotSupportedException($"Tipo {type} não suportado.")
         } ?? throw new JsonException($"Could not deserialize connection settings for database type {type}.");
+
+        if (!root.TryGetProperty(nameof(ConnectionSettings.DmlTransactionMode), out _))
+            connection.DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(type);
+
         return connection;
     }
 

--- a/DataDeveloper.Data/Models/ConnectionSettings.cs
+++ b/DataDeveloper.Data/Models/ConnectionSettings.cs
@@ -9,6 +9,13 @@ public class ConnectionSettings : ReactiveObject, IConnectionSettings
 {
     public const int DefaultStatementTimeoutSeconds = 60;
 
+    public static DmlTransactionMode GetDefaultDmlTransactionMode(DatabaseType databaseType)
+    {
+        return databaseType == DatabaseType.Oracle
+            ? DmlTransactionMode.ManualCommitRollback
+            : DmlTransactionMode.AutoCommit;
+    }
+
     [Reactive] public Guid Id { get; set; }
     [Reactive] public Guid? CredentialId { get; set; }
     [Reactive] public string Name { get; set; } = string.Empty;
@@ -20,5 +27,6 @@ public class ConnectionSettings : ReactiveObject, IConnectionSettings
     [Reactive] public bool TrustServerCertificate { get; set; }
     [Reactive] public bool AllowBlankPassword { get; set; }
     [Reactive] public int StatementTimeoutSeconds { get; set; } = DefaultStatementTimeoutSeconds;
+    [Reactive] public DmlTransactionMode DmlTransactionMode { get; set; }
     [Reactive] public DatabaseType DatabaseType { get; set; }
 }

--- a/DataDeveloper.Data/Services/StatementExecutor.cs
+++ b/DataDeveloper.Data/Services/StatementExecutor.cs
@@ -62,7 +62,9 @@ public class StatementExecutor : IStatementExecutor
 
                 if (_sqlAnalyzer.IsDmlStatement(statement))
                 {
-                    var dmlResult = await ExecuteTransactionalDmlStatement(statement, parameters, commandTimeoutSeconds, cancellationToken);
+                    var dmlResult = HasActiveTransaction || _connectionSettings.DmlTransactionMode == DmlTransactionMode.ManualCommitRollback
+                        ? await ExecuteTransactionalDmlStatement(statement, parameters, commandTimeoutSeconds, cancellationToken)
+                        : await ExecuteAutocommitDmlStatement(statement, parameters, commandTimeoutSeconds, cancellationToken);
                     result.Add(dmlResult);
                     continue;
                 }
@@ -137,6 +139,34 @@ public class StatementExecutor : IStatementExecutor
         try
         {
             await EnsureTransaction(cancellationToken);
+        }
+        finally
+        {
+            _transactionLock.Release();
+        }
+    }
+
+    public async Task<int> ExecuteCommandInTransaction(
+        EditableResultSetCommand command,
+        int? commandTimeoutSeconds = null,
+        CancellationToken cancellationToken = default)
+    {
+        await _transactionLock.WaitAsync(cancellationToken);
+        try
+        {
+            await EnsureTransaction(cancellationToken);
+
+            await using var dbCommand = CreateCommand(_transactionConnection!, command.Sql, command.Parameters, commandTimeoutSeconds);
+            dbCommand.Transaction = _transaction;
+            SetActiveCommand(dbCommand);
+            try
+            {
+                return await dbCommand.ExecuteNonQueryAsync(cancellationToken);
+            }
+            finally
+            {
+                ClearActiveCommand(dbCommand);
+            }
         }
         finally
         {
@@ -247,6 +277,29 @@ public class StatementExecutor : IStatementExecutor
         finally
         {
             _transactionLock.Release();
+        }
+    }
+
+    private async Task<StatementResult> ExecuteAutocommitDmlStatement(
+        string statement,
+        IReadOnlyDictionary<string, object?>? parameters,
+        int? commandTimeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        var watcher = Stopwatch.StartNew();
+        await using var connection = _databaseProvider.GetConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = CreateCommand(connection, statement, parameters, commandTimeoutSeconds);
+        SetActiveCommand(command);
+        try
+        {
+            var recordsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
+            watcher.Stop();
+            return new StatementResult(null, null, null, statement, watcher, recordsAffected, parameters);
+        }
+        finally
+        {
+            ClearActiveCommand(command);
         }
     }
 

--- a/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
+++ b/DataDeveloper.Tests/ConnectionSelectorViewModelTests.cs
@@ -198,6 +198,7 @@ public class ConnectionSelectorViewModelTests
         var connection = Assert.IsType<OracleConnectionSettings>(viewModel.SelectedConnection);
         Assert.Equal(1521, connection.Port);
         Assert.Equal(DatabaseType.Oracle, connection.DatabaseType);
+        Assert.Equal(DmlTransactionMode.ManualCommitRollback, connection.DmlTransactionMode);
     }
 
     [Fact]
@@ -216,6 +217,7 @@ public class ConnectionSelectorViewModelTests
         var connection = Assert.IsType<SqLiteConnectionSettings>(viewModel.SelectedConnection);
         Assert.Equal(DatabaseType.SqLite, connection.DatabaseType);
         Assert.Equal(string.Empty, connection.Database);
+        Assert.Equal(DmlTransactionMode.AutoCommit, connection.DmlTransactionMode);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
+++ b/DataDeveloper.Tests/Providers/ConnectionSettingsConverterTests.cs
@@ -45,6 +45,7 @@ public class ConnectionSettingsConverterTests
         Assert.Equal("localhost", typed.Server);
         Assert.Equal(1433, typed.Port);
         Assert.Equal(SqlServerAuthenticationMode.WindowsIntegrated, typed.AuthenticationMode);
+        Assert.Equal(DmlTransactionMode.AutoCommit, typed.DmlTransactionMode);
     }
 
     [Fact]
@@ -93,6 +94,7 @@ public class ConnectionSettingsConverterTests
         var typed = Assert.IsType<OracleConnectionSettings>(connection);
         Assert.Equal(DatabaseType.Oracle, typed.DatabaseType);
         Assert.Equal(1522, typed.Port);
+        Assert.Equal(DmlTransactionMode.ManualCommitRollback, typed.DmlTransactionMode);
     }
 
     [Fact]
@@ -153,6 +155,7 @@ public class ConnectionSettingsConverterTests
             AuthenticationMode = SqlServerAuthenticationMode.WindowsIntegrated,
             User = "sa",
             Password = "pwd",
+            DmlTransactionMode = DmlTransactionMode.ManualCommitRollback,
             Encrypt = true,
             TrustServerCertificate = false
         };
@@ -165,6 +168,7 @@ public class ConnectionSettingsConverterTests
         Assert.Equal(1433, typed.Port);
         Assert.Equal(DatabaseType.SqlServer, typed.DatabaseType);
         Assert.Equal(SqlServerAuthenticationMode.WindowsIntegrated, typed.AuthenticationMode);
+        Assert.Equal(DmlTransactionMode.ManualCommitRollback, typed.DmlTransactionMode);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/SqlCompletionProviderTests.cs
+++ b/DataDeveloper.Tests/SqlCompletionProviderTests.cs
@@ -443,6 +443,7 @@ public class SqlCompletionProviderTests
         public bool TrustServerCertificate { get; set; }
         public bool AllowBlankPassword { get; set; }
         public int StatementTimeoutSeconds { get; set; } = ConnectionSettings.DefaultStatementTimeoutSeconds;
+        public DmlTransactionMode DmlTransactionMode { get; set; } = DmlTransactionMode.AutoCommit;
         public DatabaseType DatabaseType { get; set; }
     }
 }

--- a/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
+++ b/DataDeveloper.Tests/SqliteConnectionSettingsRepositoryTests.cs
@@ -75,6 +75,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
             User = "sa",
             Password = "secret",
             StatementTimeoutSeconds = 120,
+            DmlTransactionMode = DmlTransactionMode.ManualCommitRollback,
             Encrypt = true,
             TrustServerCertificate = false
         };
@@ -90,6 +91,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
             User = "root",
             Password = "mysql-secret",
             StatementTimeoutSeconds = 240,
+            DmlTransactionMode = DmlTransactionMode.AutoCommit,
             Encrypt = false,
             TrustServerCertificate = true
         };
@@ -106,6 +108,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(sqlServer.Port, loadedSqlServer.Port);
         Assert.Equal(sqlServer.AuthenticationMode, loadedSqlServer.AuthenticationMode);
         Assert.Equal(sqlServer.StatementTimeoutSeconds, loadedSqlServer.StatementTimeoutSeconds);
+        Assert.Equal(sqlServer.DmlTransactionMode, loadedSqlServer.DmlTransactionMode);
         repository.LoadPassword(loadedSqlServer);
         Assert.Equal(sqlServer.Password, loadedSqlServer.Password);
 
@@ -115,6 +118,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(mySql.Database, loadedMySql.Database);
         Assert.Equal(mySql.Port, loadedMySql.Port);
         Assert.Equal(mySql.StatementTimeoutSeconds, loadedMySql.StatementTimeoutSeconds);
+        Assert.Equal(mySql.DmlTransactionMode, loadedMySql.DmlTransactionMode);
         repository.LoadPassword(loadedMySql);
         Assert.Equal(mySql.Password, loadedMySql.Password);
     }
@@ -191,14 +195,16 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
             Database = "xe",
             Port = 1522,
             User = "system",
-            Password = "oracle-secret"
+            Password = "oracle-secret",
+            DmlTransactionMode = DmlTransactionMode.ManualCommitRollback
         };
         var sqLite = new SqLiteConnectionSettings
         {
             Id = Guid.NewGuid(),
             Name = "SQLite",
             DatabaseType = DatabaseType.SqLite,
-            Database = "/tmp/app.db"
+            Database = "/tmp/app.db",
+            DmlTransactionMode = DmlTransactionMode.AutoCommit
         };
 
         repository.SaveAll([oracle, sqLite]);
@@ -210,11 +216,13 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
         Assert.Equal(oracle.Server, loadedOracle.Server);
         Assert.Equal(oracle.Database, loadedOracle.Database);
         Assert.Equal(oracle.Port, loadedOracle.Port);
+        Assert.Equal(oracle.DmlTransactionMode, loadedOracle.DmlTransactionMode);
         repository.LoadPassword(loadedOracle);
         Assert.Equal(oracle.Password, loadedOracle.Password);
 
         var loadedSqLite = Assert.IsType<SqLiteConnectionSettings>(loaded.Single(item => item.Id == sqLite.Id));
         Assert.Equal(sqLite.Database, loadedSqLite.Database);
+        Assert.Equal(sqLite.DmlTransactionMode, loadedSqLite.DmlTransactionMode);
     }
 
     [Fact]
@@ -384,6 +392,7 @@ public class SqliteConnectionSettingsRepositoryTests : IDisposable
 
         Assert.Equal(SqlServerAuthenticationMode.SqlLogin, loaded.AuthenticationMode);
         Assert.Equal(1433, loaded.Port);
+        Assert.Equal(DmlTransactionMode.AutoCommit, loaded.DmlTransactionMode);
     }
 
     [Fact]

--- a/DataDeveloper.Tests/StatementExecutorTransactionTests.cs
+++ b/DataDeveloper.Tests/StatementExecutorTransactionTests.cs
@@ -18,7 +18,7 @@ public class StatementExecutorTransactionTests
         try
         {
             EnsureDatabaseServices();
-            var settings = CreateSqLiteSettings(databasePath);
+            var settings = CreateSqLiteSettings(databasePath, DmlTransactionMode.ManualCommitRollback);
             var executor = settings.GetStatementExecutor();
 
             await ExecuteAndClose(executor, "create table items(id integer primary key, name text)");
@@ -45,7 +45,7 @@ public class StatementExecutorTransactionTests
         try
         {
             EnsureDatabaseServices();
-            var settings = CreateSqLiteSettings(databasePath);
+            var settings = CreateSqLiteSettings(databasePath, DmlTransactionMode.ManualCommitRollback);
             var executor = settings.GetStatementExecutor();
 
             await ExecuteAndClose(executor, "create table items(id integer primary key, name text)");
@@ -90,6 +90,61 @@ public class StatementExecutorTransactionTests
         }
     }
 
+    [Fact]
+    public async Task ExecuteStatement_AutoCommitMode_PersistsDmlWithoutPendingTransaction()
+    {
+        var databasePath = CreateDatabasePath();
+        try
+        {
+            EnsureDatabaseServices();
+            var settings = CreateSqLiteSettings(databasePath, DmlTransactionMode.AutoCommit);
+            var executor = settings.GetStatementExecutor();
+
+            await ExecuteAndClose(executor, "create table items(id integer primary key, name text)");
+            await ExecuteAndClose(executor, "insert into items(name) values ('auto')");
+
+            Assert.False(executor.HasActiveTransaction);
+            Assert.Equal(1L, await ExecuteScalar<long>(settings.GetStatementExecutor(), "select count(*) from items"));
+        }
+        finally
+        {
+            File.Delete(databasePath);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteCommandInTransaction_KeepsEditableGridCommandPendingUntilRollback()
+    {
+        var databasePath = CreateDatabasePath();
+        try
+        {
+            EnsureDatabaseServices();
+            var settings = CreateSqLiteSettings(databasePath);
+            var executor = settings.GetStatementExecutor();
+
+            await ExecuteAndClose(executor, "create table items(id integer primary key, name text)");
+
+            var command = new EditableResultSetCommand(
+                "insert into items(name) values (@name);",
+                new Dictionary<string, object?> { ["name"] = "grid" });
+            var affectedRows = await executor.ExecuteCommandInTransaction(command);
+
+            Assert.Equal(1, affectedRows);
+            Assert.True(executor.HasActiveTransaction);
+            Assert.Equal(1L, await ExecuteScalar<long>(executor, "select count(*) from items"));
+            Assert.Equal(0L, await ExecuteScalar<long>(settings.GetStatementExecutor(), "select count(*) from items"));
+
+            await executor.RollbackTransaction();
+
+            Assert.False(executor.HasActiveTransaction);
+            Assert.Equal(0L, await ExecuteScalar<long>(settings.GetStatementExecutor(), "select count(*) from items"));
+        }
+        finally
+        {
+            File.Delete(databasePath);
+        }
+    }
+
     private static async Task ExecuteAndClose(IStatementExecutor executor, string sql)
     {
         var results = await executor.ExecuteStatement(sql);
@@ -112,13 +167,16 @@ public class StatementExecutorTransactionTests
         }
     }
 
-    private static SqLiteConnectionSettings CreateSqLiteSettings(string databasePath)
+    private static SqLiteConnectionSettings CreateSqLiteSettings(
+        string databasePath,
+        DmlTransactionMode dmlTransactionMode = DmlTransactionMode.AutoCommit)
     {
         return new SqLiteConnectionSettings
         {
             Id = Guid.NewGuid(),
             Name = "Transaction test",
             DatabaseType = DatabaseType.SqLite,
+            DmlTransactionMode = dmlTransactionMode,
             Database = databasePath
         };
     }

--- a/DataDeveloper.Tests/TabDataGridViewModelTests.cs
+++ b/DataDeveloper.Tests/TabDataGridViewModelTests.cs
@@ -88,6 +88,14 @@ public class TabDataGridViewModelTests
             return Task.CompletedTask;
         }
 
+        public Task<int> ExecuteCommandInTransaction(
+            EditableResultSetCommand command,
+            int? commandTimeoutSeconds = null,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(0);
+        }
+
         public Task RollbackTransaction(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;

--- a/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
+++ b/DataDeveloper/Services/SqliteConnectionSettingsRepository.cs
@@ -53,6 +53,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   trust_server_certificate,
                                   allow_blank_password,
                                   statement_timeout_seconds,
+                                  dml_transaction_mode,
                                   server,
                                   database_name,
                                   port
@@ -80,6 +81,9 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             connectionSettings.StatementTimeoutSeconds = reader.IsDBNull(reader.GetOrdinal("statement_timeout_seconds"))
                 ? ConnectionSettings.DefaultStatementTimeoutSeconds
                 : NormalizeStatementTimeout(reader.GetInt32(reader.GetOrdinal("statement_timeout_seconds")));
+            connectionSettings.DmlTransactionMode = reader.IsDBNull(reader.GetOrdinal("dml_transaction_mode"))
+                ? ConnectionSettings.GetDefaultDmlTransactionMode(databaseType)
+                : (DmlTransactionMode)reader.GetInt32(reader.GetOrdinal("dml_transaction_mode"));
 
             switch (connectionSettings)
             {
@@ -186,6 +190,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                       trust_server_certificate,
                                       allow_blank_password,
                                       statement_timeout_seconds,
+                                      dml_transaction_mode,
                                       server,
                                       database_name,
                                       port,
@@ -204,6 +209,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                       $trustServerCertificate,
                                       $allowBlankPassword,
                                       $statementTimeoutSeconds,
+                                      $dmlTransactionMode,
                                       $server,
                                       $databaseName,
                                       $port,
@@ -223,6 +229,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
             command.Parameters.AddWithValue("$trustServerCertificate", item.TrustServerCertificate ? 1 : 0);
             command.Parameters.AddWithValue("$allowBlankPassword", item.AllowBlankPassword ? 1 : 0);
             command.Parameters.AddWithValue("$statementTimeoutSeconds", NormalizeStatementTimeout(item.StatementTimeoutSeconds));
+            command.Parameters.AddWithValue("$dmlTransactionMode", (int)item.DmlTransactionMode);
             command.Parameters.AddWithValue("$server", GetServer(item));
             command.Parameters.AddWithValue("$databaseName", GetDatabase(item));
             command.Parameters.AddWithValue("$port", GetPort(item));
@@ -277,6 +284,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   trust_server_certificate,
                                   allow_blank_password,
                                   statement_timeout_seconds,
+                                  dml_transaction_mode,
                                   server,
                                   database_name,
                                   port,
@@ -295,6 +303,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   $trustServerCertificate,
                                   $allowBlankPassword,
                                   $statementTimeoutSeconds,
+                                  $dmlTransactionMode,
                                   $server,
                                   $databaseName,
                                   $port,
@@ -311,6 +320,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   trust_server_certificate = excluded.trust_server_certificate,
                                   allow_blank_password = excluded.allow_blank_password,
                                   statement_timeout_seconds = excluded.statement_timeout_seconds,
+                                  dml_transaction_mode = excluded.dml_transaction_mode,
                                   server = excluded.server,
                                   database_name = excluded.database_name,
                                   port = excluded.port,
@@ -330,6 +340,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         command.Parameters.AddWithValue("$trustServerCertificate", connectionSettings.TrustServerCertificate ? 1 : 0);
         command.Parameters.AddWithValue("$allowBlankPassword", connectionSettings.AllowBlankPassword ? 1 : 0);
         command.Parameters.AddWithValue("$statementTimeoutSeconds", NormalizeStatementTimeout(connectionSettings.StatementTimeoutSeconds));
+        command.Parameters.AddWithValue("$dmlTransactionMode", (int)connectionSettings.DmlTransactionMode);
         command.Parameters.AddWithValue("$server", GetServer(connectionSettings));
         command.Parameters.AddWithValue("$databaseName", GetDatabase(connectionSettings));
         command.Parameters.AddWithValue("$port", GetPort(connectionSettings));
@@ -378,6 +389,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
                                   trust_server_certificate integer not null,
                                   allow_blank_password integer not null,
                                   statement_timeout_seconds integer not null default 60,
+                                  dml_transaction_mode integer null,
                                   server text not null,
                                   database_name text not null,
                                   port integer null,
@@ -388,6 +400,7 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
         command.ExecuteNonQuery();
         EnsureColumnExists(connection, "sql_server_authentication_mode", "integer not null default 0");
         EnsureColumnExists(connection, "statement_timeout_seconds", "integer not null default 60");
+        EnsureColumnExists(connection, "dml_transaction_mode", "integer null");
 
         _isInitialized = true;
     }
@@ -403,11 +416,31 @@ public class SqliteConnectionSettingsRepository : IConnectionSettingsRepository
     {
         return databaseType switch
         {
-            DatabaseType.SqlServer => new SqlServerConnectionSettings { DatabaseType = DatabaseType.SqlServer },
-            DatabaseType.Oracle => new OracleConnectionSettings { DatabaseType = DatabaseType.Oracle },
-            DatabaseType.PostgresSql => new PostgresConnectionSettings { DatabaseType = DatabaseType.PostgresSql },
-            DatabaseType.MySql => new MySqlConnectionSettings { DatabaseType = DatabaseType.MySql },
-            DatabaseType.SqLite => new SqLiteConnectionSettings { DatabaseType = DatabaseType.SqLite },
+            DatabaseType.SqlServer => new SqlServerConnectionSettings
+            {
+                DatabaseType = DatabaseType.SqlServer,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.SqlServer)
+            },
+            DatabaseType.Oracle => new OracleConnectionSettings
+            {
+                DatabaseType = DatabaseType.Oracle,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.Oracle)
+            },
+            DatabaseType.PostgresSql => new PostgresConnectionSettings
+            {
+                DatabaseType = DatabaseType.PostgresSql,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.PostgresSql)
+            },
+            DatabaseType.MySql => new MySqlConnectionSettings
+            {
+                DatabaseType = DatabaseType.MySql,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.MySql)
+            },
+            DatabaseType.SqLite => new SqLiteConnectionSettings
+            {
+                DatabaseType = DatabaseType.SqLite,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.SqLite)
+            },
             _ => throw new NotSupportedException($"Database type {databaseType} is not supported.")
         };
     }

--- a/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
+++ b/DataDeveloper/ViewModels/ConnectionSelectorViewModel.cs
@@ -49,6 +49,18 @@ public sealed class SqlServerAuthenticationOption
     public SqlServerAuthenticationMode Value { get; }
 }
 
+public sealed class DmlTransactionModeOption
+{
+    public DmlTransactionModeOption(string displayName, DmlTransactionMode value)
+    {
+        DisplayName = displayName;
+        Value = value;
+    }
+
+    public string DisplayName { get; }
+    public DmlTransactionMode Value { get; }
+}
+
 public class ConnectionSelectorViewModel : ViewModelBase
 {
     private static readonly int[] SupportedStatementTimeouts = [15, 30, 60, 120, 240, 480];
@@ -78,6 +90,11 @@ public class ConnectionSelectorViewModel : ViewModelBase
         [
             new SqlServerAuthenticationOption("SQL Server Authentication", SqlServerAuthenticationMode.SqlLogin),
             new SqlServerAuthenticationOption("Windows Authentication", SqlServerAuthenticationMode.WindowsIntegrated)
+        ];
+        DmlTransactionModes =
+        [
+            new DmlTransactionModeOption("Auto commit", DmlTransactionMode.AutoCommit),
+            new DmlTransactionModeOption("Manual commit/rollback", DmlTransactionMode.ManualCommitRollback)
         ];
         StatementTimeoutOptions = new ObservableCollection<int>(SupportedStatementTimeouts);
         AvailableDatabaseNames = new ReadOnlyObservableCollection<string>(_availableDatabaseNames);
@@ -234,6 +251,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
     public ReadOnlyObservableCollection<string> AvailableDatabaseNames { get; }
     public IReadOnlyList<ConnectionTypeFilterOption> AvailableConnectionFilters { get; }
     public IReadOnlyList<SqlServerAuthenticationOption> SqlServerAuthenticationModes { get; }
+    public IReadOnlyList<DmlTransactionModeOption> DmlTransactionModes { get; }
     public ObservableCollection<int> StatementTimeoutOptions { get; }
 
     private ConnectionSettings? _selectedConnection;
@@ -257,6 +275,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
             this.RaisePropertyChanged(nameof(UsesCredentialsForSelectedConnection));
             this.RaisePropertyChanged(nameof(SelectedSqlServerAuthenticationOption));
             this.RaisePropertyChanged(nameof(SelectedStatementTimeoutSeconds));
+            this.RaisePropertyChanged(nameof(SelectedDmlTransactionModeOption));
         }
     }
 
@@ -332,6 +351,21 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 return;
 
             SelectedConnection.StatementTimeoutSeconds = NormalizeStatementTimeout(value);
+            this.RaisePropertyChanged();
+        }
+    }
+
+    public DmlTransactionModeOption? SelectedDmlTransactionModeOption
+    {
+        get => SelectedConnection is null
+            ? null
+            : DmlTransactionModes.FirstOrDefault(option => option.Value == SelectedConnection.DmlTransactionMode);
+        set
+        {
+            if (SelectedConnection is null || value is null)
+                return;
+
+            SelectedConnection.DmlTransactionMode = value.Value;
             this.RaisePropertyChanged();
         }
     }
@@ -455,6 +489,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Encrypt = true,
                 TrustServerCertificate = false,
                 StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.SqlServer),
                 DatabaseType = DatabaseType.SqlServer
             },
             DatabaseType.Oracle => new OracleConnectionSettings
@@ -469,6 +504,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Encrypt = false,
                 TrustServerCertificate = false,
                 StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.Oracle),
                 DatabaseType = DatabaseType.Oracle
             },
             DatabaseType.PostgresSql => new PostgresConnectionSettings
@@ -483,6 +519,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Encrypt = false,
                 TrustServerCertificate = false,
                 StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.PostgresSql),
                 DatabaseType = DatabaseType.PostgresSql
             },
             DatabaseType.MySql => new MySqlConnectionSettings
@@ -497,6 +534,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Encrypt = false,
                 TrustServerCertificate = true,
                 StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.MySql),
                 DatabaseType = DatabaseType.MySql
             },
             DatabaseType.SqLite => new SqLiteConnectionSettings
@@ -509,6 +547,7 @@ public class ConnectionSelectorViewModel : ViewModelBase
                 Encrypt = false,
                 TrustServerCertificate = false,
                 StatementTimeoutSeconds = ConnectionSettings.DefaultStatementTimeoutSeconds,
+                DmlTransactionMode = ConnectionSettings.GetDefaultDmlTransactionMode(DatabaseType.SqLite),
                 DatabaseType = DatabaseType.SqLite
             },
             _ => throw new NotSupportedException($"Database type {databaseType} is not supported.")

--- a/DataDeveloper/ViewModels/TabDataGridViewModel.cs
+++ b/DataDeveloper/ViewModels/TabDataGridViewModel.cs
@@ -38,6 +38,8 @@ public class TabDataGridViewModel : BaseTabContent
     private readonly Guid _messageTargetId;
     private readonly Action? _focusMessageTab;
     private readonly Action<bool, string>? _reportExecutionStatus;
+    private readonly IStatementExecutor? _sharedStatementExecutor;
+    private readonly Action? _transactionStateChanged;
     private readonly int? _commandTimeoutSeconds;
     private readonly List<PendingDeletedGridRow> _pendingDeletedRows = [];
     private CancellationTokenSource? _loadCancellationTokenSource;
@@ -52,13 +54,17 @@ public class TabDataGridViewModel : BaseTabContent
         Guid messageTargetId,
         int? commandTimeoutSeconds = null,
         Action? focusMessageTab = null,
-        Action<bool, string>? reportExecutionStatus = null) 
+        Action<bool, string>? reportExecutionStatus = null,
+        IStatementExecutor? sharedStatementExecutor = null,
+        Action? transactionStateChanged = null) 
         : base(TabType.DataGrid, name, canClose, serviceProvider)
     {
         _eventAggregatorService = ServiceProvider.GetRequiredService<IEventAggregatorService>();
         _messageTargetId = messageTargetId;
         _focusMessageTab = focusMessageTab;
         _reportExecutionStatus = reportExecutionStatus;
+        _sharedStatementExecutor = sharedStatementExecutor;
+        _transactionStateChanged = transactionStateChanged;
         _commandTimeoutSeconds = commandTimeoutSeconds;
         ConnectionSettings = connectionSettings;
         StatementResult = statementResult;
@@ -112,6 +118,14 @@ public class TabDataGridViewModel : BaseTabContent
     {
         _loadCancellationTokenSource?.Cancel();
         await Task.CompletedTask;
+    }
+
+    public async Task RefreshAfterTransactionCompletedAsync()
+    {
+        if (IsClosed || IsBusy)
+            return;
+
+        await RefreshDataAsync();
     }
 
     public async Task LoadData()
@@ -433,10 +447,13 @@ public class TabDataGridViewModel : BaseTabContent
         var insertedCount = GridRows.OfType<EditableGridRow>().Count(row => row.State == EditableGridRowState.New);
         var updatedCount = GridRows.OfType<EditableGridRow>().Count(row => row.State == EditableGridRowState.Modified);
         var deletedCount = _pendingDeletedRows.Count;
-        var provider = ConnectionSettings.GetDatabaseProvider();
-        await using var connection = provider.GetConnection();
-        await connection.OpenAsync();
-        await using var transaction = await connection.BeginTransactionAsync();
+        var statementExecutor = CreateStatementExecutor();
+        var useSharedTransaction = ShouldUseSharedTransaction(statementExecutor);
+        var provider = useSharedTransaction ? null : ConnectionSettings.GetDatabaseProvider();
+        await using var connection = useSharedTransaction ? null : provider!.GetConnection();
+        if (connection is not null)
+            await connection.OpenAsync();
+        await using var transaction = connection is null ? null : await connection.BeginTransactionAsync();
 
         try
         {
@@ -472,7 +489,9 @@ public class TabDataGridViewModel : BaseTabContent
                 if (command is null)
                     continue;
 
-                var affectedRows = await ExecuteCommandAsync(connection, transaction, command);
+                var affectedRows = useSharedTransaction
+                    ? await statementExecutor.ExecuteCommandInTransaction(command, _commandTimeoutSeconds)
+                    : await ExecuteCommandAsync(connection!, transaction!, command, _commandTimeoutSeconds);
                 EnsureExpectedRowsWereAffected(row.State, affectedRows, index);
             }
 
@@ -488,11 +507,14 @@ public class TabDataGridViewModel : BaseTabContent
                 if (command is null)
                     continue;
 
-                var affectedRows = await ExecuteCommandAsync(connection, transaction, command);
+                var affectedRows = useSharedTransaction
+                    ? await statementExecutor.ExecuteCommandInTransaction(command, _commandTimeoutSeconds)
+                    : await ExecuteCommandAsync(connection!, transaction!, command, _commandTimeoutSeconds);
                 EnsureExpectedRowsWereAffected(EditableGridRowState.Deleted, affectedRows, pendingDeletedRow.OriginalIndex);
             }
 
-            await transaction.CommitAsync();
+            if (transaction is not null)
+                await transaction.CommitAsync();
             _pendingDeletedRows.Clear();
 
             for (var index = GridRows.Count - 1; index >= 0; index--)
@@ -509,20 +531,25 @@ public class TabDataGridViewModel : BaseTabContent
 
             RowNumber = GridRows.Count;
             RecalculatePendingChanges();
+            _transactionStateChanged?.Invoke();
             await RefreshDataAsync();
             PublishSubmitMessage(insertedCount, updatedCount, deletedCount);
         }
         catch (Exception ex)
         {
-            try
+            if (transaction is not null)
             {
-                await transaction.RollbackAsync();
-            }
-            catch
-            {
-                // Some providers auto-complete the transaction after a command failure.
+                try
+                {
+                    await transaction.RollbackAsync();
+                }
+                catch
+                {
+                    // Some providers auto-complete the transaction after a command failure.
+                }
             }
 
+            _transactionStateChanged?.Invoke();
             PublishSubmitFailureMessage(ex);
         }
         finally
@@ -550,15 +577,28 @@ public class TabDataGridViewModel : BaseTabContent
 
     protected virtual IStatementExecutor CreateStatementExecutor()
     {
-        return ConnectionSettings.GetStatementExecutor();
+        return _sharedStatementExecutor ?? ConnectionSettings.GetStatementExecutor();
+    }
+
+    private bool ShouldUseSharedTransaction(IStatementExecutor statementExecutor)
+    {
+        return _sharedStatementExecutor is not null &&
+               (statementExecutor.HasActiveTransaction ||
+                ConnectionSettings.DmlTransactionMode == DmlTransactionMode.ManualCommitRollback);
     }
 
     private void PublishSubmitMessage(int insertedCount, int updatedCount, int deletedCount)
     {
-        var message = $"Submit completed for {Name}:{Environment.NewLine}" +
+        var transactionMessage = ConnectionSettings.DmlTransactionMode == DmlTransactionMode.ManualCommitRollback ||
+                                 (_sharedStatementExecutor?.HasActiveTransaction ?? false)
+            ? "Commit or rollback the transaction to finish."
+            : "Changes committed.";
+
+        var message = $"Changes applied for {Name}:{Environment.NewLine}" +
                       $"Inserted: {insertedCount}{Environment.NewLine}" +
                       $"Updated: {updatedCount}{Environment.NewLine}" +
                       $"Deleted: {deletedCount}{Environment.NewLine}" +
+                      $"{transactionMessage}{Environment.NewLine}" +
                       $"Refreshed using:{Environment.NewLine}{StatementResult.Statement}";
         _eventAggregatorService.Publish(new ShowResultMessageEvent(_messageTargetId, message));
         _focusMessageTab?.Invoke();
@@ -584,12 +624,18 @@ public class TabDataGridViewModel : BaseTabContent
             $"Could not {operation} row {rowIndex + 1}. The record may have been changed or removed by another process.");
     }
 
-    private static async Task<int> ExecuteCommandAsync(DbConnection connection, DbTransaction transaction, EditableResultSetCommand command)
+    private static async Task<int> ExecuteCommandAsync(
+        DbConnection connection,
+        DbTransaction transaction,
+        EditableResultSetCommand command,
+        int? commandTimeoutSeconds)
     {
         await using var dbCommand = connection.CreateCommand();
         dbCommand.Transaction = transaction;
         dbCommand.CommandType = CommandType.Text;
         dbCommand.CommandText = command.Sql;
+        if (commandTimeoutSeconds.HasValue)
+            dbCommand.CommandTimeout = commandTimeoutSeconds.Value;
 
         foreach (var parameter in command.Parameters)
         {

--- a/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
+++ b/DataDeveloper/ViewModels/TabQueryEditorViewModel.cs
@@ -237,7 +237,9 @@ public class TabQueryEditorViewModel : BaseTabContent
                                 StatementIsRunning = isVisible;
                                 IsExecutionStatusVisible = isVisible;
                                 ExecutionStatusMessage = message;
-                            });
+                            },
+                            _statementExecutor,
+                            RefreshTransactionState);
                         tabResult.IsEditorOperationInProgress = StatementIsRunning;
                         tabResult.WhenAnyValue(vm => vm.SelectedPage).Subscribe(page => _cachePages[statementResult.Statement] = page);
                         
@@ -314,7 +316,11 @@ public class TabQueryEditorViewModel : BaseTabContent
         {
             await _statementExecutor.CommitTransaction();
             RefreshTransactionState();
-            _eventAggregatorService.Publish(new ShowResultMessageEvent(this.Id, "Transaction committed."));
+            var refreshError = await RefreshResultTabsAfterTransactionCompleted();
+            var message = refreshError is null
+                ? "Transaction committed."
+                : $"Transaction committed. Result refresh failed: {refreshError}";
+            _eventAggregatorService.Publish(new ShowResultMessageEvent(this.Id, message));
             this.SelectedTabIndex = 0;
             return true;
         }
@@ -333,7 +339,11 @@ public class TabQueryEditorViewModel : BaseTabContent
         {
             await _statementExecutor.RollbackTransaction();
             RefreshTransactionState();
-            _eventAggregatorService.Publish(new ShowResultMessageEvent(this.Id, "Transaction rolled back."));
+            var refreshError = await RefreshResultTabsAfterTransactionCompleted();
+            var message = refreshError is null
+                ? "Transaction rolled back."
+                : $"Transaction rolled back. Result refresh failed: {refreshError}";
+            _eventAggregatorService.Publish(new ShowResultMessageEvent(this.Id, message));
             this.SelectedTabIndex = 0;
             return true;
         }
@@ -344,6 +354,28 @@ public class TabQueryEditorViewModel : BaseTabContent
             this.SelectedTabIndex = 0;
             return false;
         }
+    }
+
+    private async Task<string?> RefreshResultTabsAfterTransactionCompleted()
+    {
+        var resultTabs = Tabs
+            .OfType<TabDataGridViewModel>()
+            .Where(tab => !tab.IsClosed)
+            .ToList();
+
+        foreach (var resultTab in resultTabs)
+        {
+            try
+            {
+                await resultTab.RefreshAfterTransactionCompletedAsync();
+            }
+            catch (Exception ex)
+            {
+                return ex.Message;
+            }
+        }
+
+        return null;
     }
 
     private void RefreshTransactionState()

--- a/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
+++ b/DataDeveloper/Views/ConnectionSelectorDialogView.axaml
@@ -154,17 +154,30 @@
                 </Grid>
 
                 <Grid RowDefinitions="Auto,Auto"
-                      IsVisible="{Binding UsesSqlServerAuthenticationMode}">
-                    <TextBlock Grid.Row="0" Text="Authentication" />
-                    <ComboBox Grid.Row="1"
+                      ColumnDefinitions="*,*"
+                      IsVisible="{Binding UsesSqlServerAuthenticationMode}"
+                      ColumnSpacing="8"
+                      >
+                    <TextBlock Grid.Column="0" Grid.Row="0" Text="Authentication" />
+                    <ComboBox Grid.Column="0" Grid.Row="1"
                               ItemsSource="{Binding SqlServerAuthenticationModes}"
-                              SelectedItem="{Binding SelectedSqlServerAuthenticationOption, Mode=TwoWay}">
+                              SelectedItem="{Binding SelectedSqlServerAuthenticationOption, Mode=TwoWay}"
+                              HorizontalAlignment="Stretch"
+                              >
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding DisplayName}" />
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Grid.RowSpan="2"
+                               Text="For LocalDB,&#10;use SQL Server with Windows Authentication&#10;and a server such as (localdb)\MSSQLLocalDB."
+                               FontSize="10.5"
+                               Foreground="DarkGoldenrod"
+                               TextWrapping="WrapWithOverflow"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Stretch"
+                               IsVisible="{Binding IsSqlServerConnectionSelected}" />
                 </Grid>
 
                 <StackPanel Orientation="Horizontal"
@@ -211,12 +224,6 @@
                            TextWrapping="Wrap"
                            IsVisible="{Binding IsSqlServerConnectionSelected}" />
 
-                <TextBlock Text="For LocalDB, use SQL Server with Windows Authentication and a server such as (localdb)\MSSQLLocalDB."
-                           FontSize="11"
-                           Foreground="DarkGoldenrod"
-                           TextWrapping="Wrap"
-                           IsVisible="{Binding IsSqlServerConnectionSelected}" />
-
                 <TextBlock Text="For MySQL, use 'Encrypt connection' to require TLS. 'Trust server certificate' relaxes certificate validation."
                            FontSize="11"
                            Foreground="DarkGoldenrod"
@@ -247,16 +254,26 @@
                            TextWrapping="Wrap"
                            IsVisible="{Binding IsSecureStorageUnavailable}" />
 
-                <Grid ColumnDefinitions="Auto,Auto,*"
-                      ColumnSpacing="8"
-                      VerticalAlignment="Center">
-                    <TextBlock Grid.Column="0"
-                               Text="Default statement timeout"
-                               FontSize="11"
-                               Foreground="DarkGoldenrod"
-                               VerticalAlignment="Center" />
-                    <ComboBox Grid.Column="1"
-                              Width="110"
+                <Grid ColumnDefinitions="*,*"
+                      ColumnSpacing="12"
+                      RowSpacing="8"
+                      RowDefinitions="Auto, Auto"
+                      >
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="DML transaction mode" />
+                    <ComboBox Grid.Row="1" Grid.Column="0"
+                              HorizontalAlignment="Stretch"
+                              ItemsSource="{Binding DmlTransactionModes}"
+                              SelectedItem="{Binding SelectedDmlTransactionModeOption, Mode=TwoWay}"
+                              IsEnabled="{Binding IsEditing}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayName}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                    <TextBlock Grid.Row="0" Grid.Column="1" Text="Default statement timeout" />
+                    <ComboBox Grid.Row="1" Grid.Column="1"
+                              HorizontalAlignment="Stretch"
                               ItemsSource="{Binding StatementTimeoutOptions}"
                               SelectedItem="{Binding SelectedStatementTimeoutSeconds, Mode=TwoWay}"
                               IsEnabled="{Binding IsEditing}" />

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ DataDeveloper currently supports SQL Server, Oracle, MySQL, PostgreSQL, and SQLi
 - Browse database schema from a dedicated explorer panel
 - Open multiple query editors per connection
 - Execute SQL statements and inspect results in tabbed result views
+- Configure DML transaction mode per connection, using either auto commit or manual commit/rollback
 - Use provider-aware SQL completion for tables and columns
 - Navigate query results with the custom `NextGrid` control
 - Detect named SQL parameters and fill them through a side panel in the editor


### PR DESCRIPTION
## Summary
- add per-connection DML transaction mode with Auto commit and Manual commit/rollback
- default Oracle to manual commit/rollback and other providers to auto commit
- make SQL execution and editable grid saves honor the configured mode while preserving explicit transactions
- persist the setting, migrate existing local connection storage, and document it in README

## Tests
- dotnet test DataDeveloper.sln
- dotnet run --project DataDeveloper/DataDeveloper.csproj