### PR TITLE
Add SQL function completion insight

### DIFF
--- a/DataDeveloper.Tests/SqlCompletionProviderTests.cs
+++ b/DataDeveloper.Tests/SqlCompletionProviderTests.cs
@@ -287,6 +287,97 @@ public class SqlCompletionProviderTests
     }
 
     [Fact]
+    public async Task GetCompletionsAsync_ForColumn_ShowsSourceAndDataTypeInDescription()
+    {
+        var connection = new TestConnectionSettings { DatabaseType = DatabaseType.SqlServer };
+        SeedSchemaCache(
+            connection.Id,
+            "temp",
+            ("id", "int", 0, 0, 0),
+            ("campo1", "varchar", 100, 0, 0),
+            ("campo3", "decimal", 0, 10, 3));
+
+        var sql = "select ";
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, sql.Length);
+
+        var completions = await SqlCompletionProvider.GetCompletionsAsync(connection, sql, sql.Length, request);
+
+        var id = Assert.IsType<SqlCompletionData>(completions.Single(item => item.Text == "id"));
+        var campo1 = Assert.IsType<SqlCompletionData>(completions.Single(item => item.Text == "campo1"));
+        var campo3 = Assert.IsType<SqlCompletionData>(completions.Single(item => item.Text == "campo3"));
+        Assert.Equal("from temp int", id.Description);
+        Assert.Equal("from temp varchar (100)", campo1.Description);
+        Assert.Equal("from temp decimal(10, 3)", campo3.Description);
+    }
+
+    [Fact]
+    public async Task GetCompletionsAsync_AfterSelectSpace_ReturnsProviderFunctions()
+    {
+        var connection = new TestConnectionSettings { DatabaseType = DatabaseType.SqlServer };
+        SeedSchemaCache(connection.Id, "clientes", "id", "nome");
+
+        var sql = "select ";
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, sql.Length);
+
+        var completions = await SqlCompletionProvider.GetCompletionsAsync(connection, sql, sql.Length, request);
+
+        var getDate = Assert.IsType<SqlCompletionData>(completions.Single(item => item.Text == "GETDATE"));
+        Assert.Equal(CompletionItemKind.Function, getDate.Kind);
+        Assert.Equal("Returns the current database system timestamp.", getDate.Description);
+        Assert.Equal("returns date/time", getDate.Detail);
+        Assert.Contains(completions, item => item.Text == "SUM");
+    }
+
+    [Fact]
+    public async Task GetCompletionsAsync_AfterSelectWord_FiltersProviderFunctions()
+    {
+        var connection = new TestConnectionSettings { DatabaseType = DatabaseType.Oracle };
+        SeedSchemaCache(connection.Id, "clientes", "id", "nome");
+
+        var sql = "select nv";
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, sql.Length);
+
+        var completions = await SqlCompletionProvider.GetCompletionsAsync(connection, sql, sql.Length, request);
+
+        Assert.Contains(completions, item => item.Text == "NVL");
+        Assert.Contains(completions, item => item.Text == "NVL2");
+        Assert.DoesNotContain(completions, item => item.Text == "SYSDATE");
+    }
+
+    [Fact]
+    public async Task GetCompletionsAsync_AfterFrom_DoesNotReturnFunctions()
+    {
+        var connection = new TestConnectionSettings { DatabaseType = DatabaseType.SqlServer };
+        SeedSchemaCache(connection.Id, "clientes", "id", "nome");
+
+        var sql = "select * from ";
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, sql.Length);
+
+        var completions = await SqlCompletionProvider.GetCompletionsAsync(connection, sql, sql.Length, request);
+
+        Assert.Contains(completions, item => item.Text == "clientes");
+        Assert.DoesNotContain(completions, item => item.Text == "GETDATE");
+        Assert.DoesNotContain(completions.OfType<SqlCompletionData>(), item => item.Kind == CompletionItemKind.Function);
+    }
+
+    [Fact]
+    public async Task GetCompletionsAsync_AfterAliasDot_DoesNotReturnFunctions()
+    {
+        var connection = new TestConnectionSettings { DatabaseType = DatabaseType.PostgresSql };
+        SeedSchemaCache(connection.Id, "clientes", "id", "nome");
+
+        var sql = "select c. from clientes c";
+        var caretOffset = "select c.".Length;
+        var request = SqlCompletionProvider.GetManualCompletionRequest(sql, caretOffset);
+
+        var completions = await SqlCompletionProvider.GetCompletionsAsync(connection, sql, caretOffset, request);
+
+        Assert.Contains(completions, item => item.Text == "id");
+        Assert.DoesNotContain(completions, item => item.Text == "NOW");
+        Assert.DoesNotContain(completions.OfType<SqlCompletionData>(), item => item.Kind == CompletionItemKind.Function);
+    }
+
+    [Fact]
     public async Task GetCompletionsAsync_AfterSelectSpaceWithFromTable_ReturnsColumnsOnlyFromReferencedTable()
     {
         var connection = new TestConnectionSettings { DatabaseType = DatabaseType.SqlServer };
@@ -381,10 +472,31 @@ public class SqlCompletionProviderTests
 
     private static void SeedSchemaCache(Guid connectionId, string tableName, params string[] columns)
     {
+        SeedSchemaCache(connectionId, (tableName, columns.Select(column => (column, string.Empty, 0, 0, 0)).ToArray()));
+    }
+
+    private static void SeedSchemaCache(
+        Guid connectionId,
+        string tableName,
+        params (string Name, string DataType, int Length, int Precision, int Scale)[] columns)
+    {
         SeedSchemaCache(connectionId, (tableName, columns));
     }
 
     private static void SeedSchemaCache(Guid connectionId, params (string TableName, string[] Columns)[] tablesToSeed)
+    {
+        SeedSchemaCache(
+            connectionId,
+            tablesToSeed
+                .Select(table => (
+                    table.TableName,
+                    table.Columns.Select(column => (column, string.Empty, 0, 0, 0)).ToArray()))
+                .ToArray());
+    }
+
+    private static void SeedSchemaCache(
+        Guid connectionId,
+        params (string TableName, (string Name, string DataType, int Length, int Precision, int Scale)[] Columns)[] tablesToSeed)
     {
         var providerType = typeof(SqlCompletionProvider);
         var cacheField = providerType.GetField("SchemaCache", BindingFlags.Static | BindingFlags.NonPublic)
@@ -393,6 +505,8 @@ public class SqlCompletionProviderTests
 
         var cacheType = providerType.GetNestedType("SchemaCompletionCache", BindingFlags.NonPublic)
                        ?? throw new InvalidOperationException("Schema completion cache type not found.");
+        var columnInfoType = providerType.GetNestedType("ColumnCompletionInfo", BindingFlags.NonPublic)
+                             ?? throw new InvalidOperationException("Column completion info type not found.");
         var cache = Activator.CreateInstance(cacheType) ?? throw new InvalidOperationException("Could not create schema cache.");
 
         cacheType.GetProperty("TablesLoaded")!.SetValue(cache, true);
@@ -412,13 +526,35 @@ public class SqlCompletionProviderTests
             tableNodes[$"`{tableName}`"] = schemaNode;
             tableNodes[$"\"{tableName}\""] = schemaNode;
 
-            columnsByTable[tableName] = columns;
+            columnsByTable[tableName] = CreateColumnInfoArray(columnInfoType, columns);
             loadedTables.Add(tableName);
         }
 
         var tryAddMethod = cacheDictionary.GetType().GetMethod("TryAdd")
                           ?? throw new InvalidOperationException("Schema cache TryAdd method not found.");
         _ = tryAddMethod.Invoke(cacheDictionary, [connectionId, cache]);
+    }
+
+    private static Array CreateColumnInfoArray(
+        Type columnInfoType,
+        (string Name, string DataType, int Length, int Precision, int Scale)[] columns)
+    {
+        var array = Array.CreateInstance(columnInfoType, columns.Length);
+        for (var index = 0; index < columns.Length; index++)
+        {
+            var column = columns[index];
+            var columnInfo = Activator.CreateInstance(
+                                 columnInfoType,
+                                 column.Name,
+                                 column.DataType,
+                                 column.Length,
+                                 column.Precision,
+                                 column.Scale)
+                             ?? throw new InvalidOperationException("Could not create column completion info.");
+            array.SetValue(columnInfo, index);
+        }
+
+        return array;
     }
 
     private static SchemaNode CreateSchemaNode(NodeType nodeType, string name)

--- a/DataDeveloper.Tests/SqlFunctionCallContextDetectorTests.cs
+++ b/DataDeveloper.Tests/SqlFunctionCallContextDetectorTests.cs
@@ -1,0 +1,89 @@
+using DataDeveloper.Services;
+using Xunit;
+
+namespace DataDeveloper.Tests;
+
+public class SqlFunctionCallContextDetectorTests
+{
+    [Fact]
+    public void Detect_AfterOpenParen_ReturnsFunctionAndFirstArgument()
+    {
+        var sql = "select sum(";
+
+        var context = SqlFunctionCallContextDetector.Detect(sql, sql.Length);
+
+        Assert.NotNull(context);
+        Assert.Equal("sum", context!.FunctionName);
+        Assert.Equal(0, context.ArgumentIndex);
+    }
+
+    [Fact]
+    public void Detect_AfterComma_ReturnsSecondArgument()
+    {
+        var sql = "select dateadd(day, ";
+
+        var context = SqlFunctionCallContextDetector.Detect(sql, sql.Length);
+
+        Assert.NotNull(context);
+        Assert.Equal("dateadd", context!.FunctionName);
+        Assert.Equal(1, context.ArgumentIndex);
+    }
+
+    [Fact]
+    public void Detect_IgnoresNestedComma_ReturnsOuterFunctionArgument()
+    {
+        var sql = "select coalesce(nullif(name, ''), ";
+
+        var context = SqlFunctionCallContextDetector.Detect(sql, sql.Length);
+
+        Assert.NotNull(context);
+        Assert.Equal("coalesce", context!.FunctionName);
+        Assert.Equal(1, context.ArgumentIndex);
+    }
+
+    [Fact]
+    public void Detect_IgnoresCommaInsideString()
+    {
+        var sql = "select coalesce('a,b', ";
+
+        var context = SqlFunctionCallContextDetector.Detect(sql, sql.Length);
+
+        Assert.NotNull(context);
+        Assert.Equal("coalesce", context!.FunctionName);
+        Assert.Equal(1, context.ArgumentIndex);
+    }
+
+    [Fact]
+    public void Detect_IgnoresFunctionLikeTextInsideComment()
+    {
+        var sql = "select -- coalesce(\ncount(";
+
+        var context = SqlFunctionCallContextDetector.Detect(sql, sql.Length);
+
+        Assert.NotNull(context);
+        Assert.Equal("count", context!.FunctionName);
+        Assert.Equal(0, context.ArgumentIndex);
+    }
+
+    [Fact]
+    public void Detect_AfterClosedParen_ReturnsNull()
+    {
+        var sql = "select sum(value)";
+
+        var context = SqlFunctionCallContextDetector.Detect(sql, sql.Length);
+
+        Assert.Null(context);
+    }
+
+    [Fact]
+    public void Detect_ReturnsInnermostFunction()
+    {
+        var sql = "select coalesce(nullif(";
+
+        var context = SqlFunctionCallContextDetector.Detect(sql, sql.Length);
+
+        Assert.NotNull(context);
+        Assert.Equal("nullif", context!.FunctionName);
+        Assert.Equal(0, context.ArgumentIndex);
+    }
+}

--- a/DataDeveloper/Services/SqlCompletionProvider.cs
+++ b/DataDeveloper/Services/SqlCompletionProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Avalonia.Input;
 using Avalonia.Media;
 using AvaloniaEdit.CodeCompletion;
 using AvaloniaEdit.Document;
@@ -138,8 +139,29 @@ public static class SqlCompletionProvider
                 var columns = await GetColumnsForSourceAsync(connectionSettings, cache, source, cteDefinitions);
                 foreach (var column in columns)
                 {
-                    completions.TryAdd(column, new SqlCompletionData(column, $"Column from {source.Name}", CompletionItemKind.Column, GetObjectPriority(CompletionKind.Column, request.Context.Clause)));
+                    completions.TryAdd(
+                        column.Name,
+                        new SqlCompletionData(
+                            column.Name,
+                            FormatColumnCompletionDescription(source.Name, column),
+                            CompletionItemKind.Column,
+                            GetObjectPriority(CompletionKind.Column, request.Context.Clause)));
                 }
+            }
+        }
+
+        if (ShouldIncludeFunctions(request.Context))
+        {
+            foreach (var function in SqlFunctionCatalog.GetFunctions(connectionSettings.DatabaseType))
+            {
+                completions.TryAdd(
+                    function.Name,
+                    new SqlCompletionData(
+                        function.Name,
+                        function.Description,
+                        CompletionItemKind.Function,
+                        GetFunctionPriority(request.Context.Clause, function.Category),
+                        $"returns {function.ReturnType}"));
             }
         }
 
@@ -149,6 +171,37 @@ public static class SqlCompletionProvider
             .ThenBy(item => item.Text)
             .Cast<ICompletionData>()
             .ToList();
+    }
+
+    private static bool ShouldIncludeFunctions(CompletionContext context)
+    {
+        if (!string.IsNullOrWhiteSpace(context.ObjectNameBeforeDot) ||
+            context.IsInsideInsertColumnList)
+            return false;
+
+        return context.Trigger is CompletionTrigger.Columns or CompletionTrigger.Any &&
+               context.Clause is (SqlClause.None or
+                   SqlClause.Select or
+                   SqlClause.Where or
+                   SqlClause.GroupBy or
+                   SqlClause.OrderBy or
+                   SqlClause.Set or
+                   SqlClause.Delete);
+    }
+
+    private static double GetFunctionPriority(SqlClause clause, SqlFunctionCategory category)
+    {
+        var basePriority = clause switch
+        {
+            SqlClause.Select or SqlClause.Where or SqlClause.Set => 30,
+            SqlClause.GroupBy or SqlClause.OrderBy => 35,
+            _ => 40
+        };
+
+        return category == SqlFunctionCategory.Aggregate &&
+               clause is (SqlClause.Select or SqlClause.GroupBy or SqlClause.OrderBy)
+            ? basePriority - 2
+            : basePriority;
     }
 
     public static int GetCompletionStartOffset(string editorText, int caretOffset)
@@ -203,25 +256,60 @@ public static class SqlCompletionProvider
 
         cache.ColumnsByTable[tableName] = tableNode.Children
             .Where(node => node.NodeType == NodeType.Column)
-            .Select(node => node.Name)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(name => name)
+            .Select(CreateColumnCompletionInfo)
+            .DistinctBy(column => column.Name, StringComparer.OrdinalIgnoreCase)
+            .OrderBy(column => column.Name)
             .ToArray();
 
         cache.LoadedTables.Add(tableName);
     }
 
-    private static async Task<string[]> GetColumnsForSourceAsync(
+    private static async Task<IReadOnlyList<ColumnCompletionInfo>> GetColumnsForSourceAsync(
         IConnectionSettings connectionSettings,
         SchemaCompletionCache cache,
         CompletionSource source,
         IReadOnlyDictionary<string, string[]> cteDefinitions)
     {
         if (source.Kind == CompletionKind.Cte)
-            return cteDefinitions.TryGetValue(source.Name, out var cteColumns) ? cteColumns : Array.Empty<string>();
+        {
+            return cteDefinitions.TryGetValue(source.Name, out var cteColumns)
+                ? cteColumns.Select(column => new ColumnCompletionInfo(column, string.Empty, 0, 0, 0)).ToArray()
+                : Array.Empty<ColumnCompletionInfo>();
+        }
 
         await EnsureColumnsLoadedAsync(connectionSettings, cache, source.Name);
-        return cache.ColumnsByTable.TryGetValue(source.Name, out var tableColumns) ? tableColumns : Array.Empty<string>();
+        return cache.ColumnsByTable.TryGetValue(source.Name, out var tableColumns) ? tableColumns : Array.Empty<ColumnCompletionInfo>();
+    }
+
+    private static ColumnCompletionInfo CreateColumnCompletionInfo(SchemaNode node)
+    {
+        return node.Tag is ColumnModel column
+            ? new ColumnCompletionInfo(column.Name, column.DataType, column.Length, column.Precision, column.Scale)
+            : new ColumnCompletionInfo(node.Name, string.Empty, 0, 0, 0);
+    }
+
+    private static string FormatColumnCompletionDescription(string sourceName, ColumnCompletionInfo column)
+    {
+        var dataType = FormatColumnDataType(column);
+        return string.IsNullOrWhiteSpace(dataType)
+            ? $"from {sourceName}"
+            : $"from {sourceName} {dataType}";
+    }
+
+    private static string FormatColumnDataType(ColumnCompletionInfo column)
+    {
+        if (string.IsNullOrWhiteSpace(column.DataType))
+            return string.Empty;
+
+        var dataType = column.DataType;
+        return dataType.ToLowerInvariant() switch
+        {
+            "varchar" or "nvarchar" or "char" or "nchar" or "binary" or "varbinary"
+                => column.Length != 0 ? $"{dataType} ({(column.Length == -1 ? "max" : column.Length)})" : dataType,
+            "decimal" or "numeric" or "number"
+                => column.Precision != 0 ? $"{dataType}({column.Precision}{(column.Scale != 0 ? $", {column.Scale}" : string.Empty)})" : dataType,
+            _ => dataType
+        };
     }
 
     private static CompletionSource? ResolveSource(
@@ -1023,9 +1111,11 @@ public static class SqlCompletionProvider
         public bool TablesLoaded { get; set; }
         public HashSet<string> Tables { get; } = new(StringComparer.OrdinalIgnoreCase);
         public Dictionary<string, SchemaNode> TableNodes { get; } = new(StringComparer.OrdinalIgnoreCase);
-        public Dictionary<string, string[]> ColumnsByTable { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, ColumnCompletionInfo[]> ColumnsByTable { get; } = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<string> LoadedTables { get; } = new(StringComparer.OrdinalIgnoreCase);
     }
+
+    private sealed record ColumnCompletionInfo(string Name, string DataType, int Length, int Precision, int Scale);
 
     public enum SqlClause
     {
@@ -1094,10 +1184,11 @@ public enum CompletionItemKind
 {
     Table,
     Column,
-    Cte
+    Cte,
+    Function
 }
 
-public sealed record SqlCompletionData(string Text, string Description, CompletionItemKind Kind, double Priority = 0) : ICompletionData
+public sealed record SqlCompletionData(string Text, string Description, CompletionItemKind Kind, double Priority = 0, string? Detail = null) : ICompletionData
 {
     public IImage? Image => null;
     public object Content => BuildContent();
@@ -1105,7 +1196,12 @@ public sealed record SqlCompletionData(string Text, string Description, Completi
 
     public void Complete(TextArea textArea, ISegment completionSegment, EventArgs insertionRequestEventArgs)
     {
-        textArea.Document.Replace(completionSegment, Text);
+        var insertionText = Kind == CompletionItemKind.Function &&
+                            insertionRequestEventArgs is TextInputEventArgs { Text: "(" }
+            ? $"{Text}("
+            : Text;
+
+        textArea.Document.Replace(completionSegment, insertionText);
     }
 
     private object BuildContent()
@@ -1134,7 +1230,7 @@ public sealed record SqlCompletionData(string Text, string Description, Completi
 
         var kind = new Avalonia.Controls.TextBlock
         {
-            Text = Description,
+            Text = Detail ?? Description,
             Foreground = Avalonia.Media.Brushes.Gray,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
             Margin = new Avalonia.Thickness(10, 0, 0, 0),
@@ -1160,6 +1256,7 @@ public sealed record SqlCompletionData(string Text, string Description, Completi
             CompletionItemKind.Table => Avalonia.Media.Brushes.DeepSkyBlue,
             CompletionItemKind.Column => Avalonia.Media.Brushes.LightGreen,
             CompletionItemKind.Cte => Avalonia.Media.Brushes.Goldenrod,
+            CompletionItemKind.Function => Avalonia.Media.Brushes.Khaki,
             _ => Avalonia.Media.Brushes.White
         };
     }
@@ -1171,6 +1268,7 @@ public sealed record SqlCompletionData(string Text, string Description, Completi
             CompletionItemKind.Table => "\U000F04EB",
             CompletionItemKind.Column => "\U000F08DF",
             CompletionItemKind.Cte => "\U000F01BC",
+            CompletionItemKind.Function => "\U000F0295",
             _ => "\U000F09EE"
         };
     }

--- a/DataDeveloper/Services/SqlFunctionCallContextDetector.cs
+++ b/DataDeveloper/Services/SqlFunctionCallContextDetector.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+
+namespace DataDeveloper.Services;
+
+public sealed record SqlFunctionCallContext(string FunctionName, int ArgumentIndex);
+
+public static class SqlFunctionCallContextDetector
+{
+    public static SqlFunctionCallContext? Detect(string editorText, int caretOffset)
+    {
+        if (string.IsNullOrEmpty(editorText) || caretOffset <= 0)
+            return null;
+
+        var scanLength = Math.Min(caretOffset, editorText.Length);
+        var stack = new List<FunctionFrame>();
+        var state = ScanState.Normal;
+
+        for (var index = 0; index < scanLength; index++)
+        {
+            var ch = editorText[index];
+            var next = index + 1 < scanLength ? editorText[index + 1] : '\0';
+
+            switch (state)
+            {
+                case ScanState.LineComment:
+                    if (ch is '\r' or '\n')
+                        state = ScanState.Normal;
+                    continue;
+                case ScanState.BlockComment:
+                    if (ch == '*' && next == '/')
+                    {
+                        index++;
+                        state = ScanState.Normal;
+                    }
+                    continue;
+                case ScanState.SingleQuotedString:
+                    if (ch == '\'' && next == '\'')
+                    {
+                        index++;
+                        continue;
+                    }
+                    if (ch == '\'')
+                        state = ScanState.Normal;
+                    continue;
+                case ScanState.DoubleQuotedIdentifier:
+                    if (ch == '"' && next == '"')
+                    {
+                        index++;
+                        continue;
+                    }
+                    if (ch == '"')
+                        state = ScanState.Normal;
+                    continue;
+                case ScanState.BracketQuotedIdentifier:
+                    if (ch == ']')
+                        state = ScanState.Normal;
+                    continue;
+                case ScanState.BacktickQuotedIdentifier:
+                    if (ch == '`')
+                        state = ScanState.Normal;
+                    continue;
+            }
+
+            if (ch == '-' && next == '-')
+            {
+                index++;
+                state = ScanState.LineComment;
+                continue;
+            }
+
+            if (ch == '/' && next == '*')
+            {
+                index++;
+                state = ScanState.BlockComment;
+                continue;
+            }
+
+            if (ch == '\'')
+            {
+                state = ScanState.SingleQuotedString;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                state = ScanState.DoubleQuotedIdentifier;
+                continue;
+            }
+
+            if (ch == '[')
+            {
+                state = ScanState.BracketQuotedIdentifier;
+                continue;
+            }
+
+            if (ch == '`')
+            {
+                state = ScanState.BacktickQuotedIdentifier;
+                continue;
+            }
+
+            if (ch == '(')
+            {
+                stack.Add(new FunctionFrame(ReadFunctionNameBeforeOpenParen(editorText, index), 0));
+                continue;
+            }
+
+            if (ch == ')')
+            {
+                if (stack.Count > 0)
+                    stack.RemoveAt(stack.Count - 1);
+                continue;
+            }
+
+            if (ch == ',' && stack.Count > 0)
+            {
+                var topIndex = stack.Count - 1;
+                stack[topIndex] = stack[topIndex] with { ArgumentIndex = stack[topIndex].ArgumentIndex + 1 };
+            }
+        }
+
+        for (var index = stack.Count - 1; index >= 0; index--)
+        {
+            var frame = stack[index];
+            if (!string.IsNullOrWhiteSpace(frame.FunctionName))
+                return new SqlFunctionCallContext(frame.FunctionName, frame.ArgumentIndex);
+        }
+
+        return null;
+    }
+
+    private static string? ReadFunctionNameBeforeOpenParen(string text, int openParenIndex)
+    {
+        var index = openParenIndex - 1;
+        while (index >= 0 && char.IsWhiteSpace(text[index]))
+            index--;
+
+        var end = index + 1;
+        while (index >= 0 && IsIdentifierCharacter(text[index]))
+            index--;
+
+        if (end <= index + 1)
+            return null;
+
+        var functionName = text[(index + 1)..end];
+        return string.IsNullOrWhiteSpace(functionName) ? null : functionName;
+    }
+
+    private static bool IsIdentifierCharacter(char ch)
+    {
+        return char.IsLetterOrDigit(ch) || ch is '_' or '$' or '#';
+    }
+
+    private readonly record struct FunctionFrame(string? FunctionName, int ArgumentIndex);
+
+    private enum ScanState
+    {
+        Normal,
+        LineComment,
+        BlockComment,
+        SingleQuotedString,
+        DoubleQuotedIdentifier,
+        BracketQuotedIdentifier,
+        BacktickQuotedIdentifier
+    }
+}

--- a/DataDeveloper/Services/SqlFunctionCatalog.cs
+++ b/DataDeveloper/Services/SqlFunctionCatalog.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DataDeveloper.Data.Enums;
+
+namespace DataDeveloper.Services;
+
+public enum SqlFunctionCategory
+{
+    Aggregate,
+    Conversion,
+    DateTime,
+    Math,
+    String,
+    NullHandling
+}
+
+public sealed record SqlFunctionDefinition(
+    string Name,
+    string Signature,
+    string Description,
+    string ReturnType,
+    SqlFunctionCategory Category,
+    IReadOnlyList<string> Parameters,
+    bool AcceptsAdditionalArguments);
+
+public static class SqlFunctionCatalog
+{
+    private static readonly IReadOnlyDictionary<DatabaseType, IReadOnlyList<SqlFunctionDefinition>> FunctionsByProvider =
+        new Dictionary<DatabaseType, IReadOnlyList<SqlFunctionDefinition>>
+        {
+            [DatabaseType.SqlServer] =
+            [
+                Function("COUNT", "COUNT(expression)", "Returns the number of items in a group.", SqlFunctionCategory.Aggregate),
+                Function("SUM", "SUM(expression)", "Returns the sum of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("AVG", "AVG(expression)", "Returns the average of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("MIN", "MIN(expression)", "Returns the minimum value.", SqlFunctionCategory.Aggregate),
+                Function("MAX", "MAX(expression)", "Returns the maximum value.", SqlFunctionCategory.Aggregate),
+                Function("GETDATE", "GETDATE()", "Returns the current database system timestamp.", SqlFunctionCategory.DateTime),
+                Function("DATEADD", "DATEADD(datepart, number, date)", "Adds an interval to a date.", SqlFunctionCategory.DateTime),
+                Function("DATEDIFF", "DATEDIFF(datepart, startdate, enddate)", "Returns the difference between two dates.", SqlFunctionCategory.DateTime),
+                Function("ISNULL", "ISNULL(check_expression, replacement_value)", "Replaces null with the specified value.", SqlFunctionCategory.NullHandling),
+                Function("COALESCE", "COALESCE(expression, ...)", "Returns the first non-null expression.", SqlFunctionCategory.NullHandling),
+                Function("CAST", "CAST(expression AS data_type)", "Converts an expression to another data type.", SqlFunctionCategory.Conversion),
+                Function("CONVERT", "CONVERT(data_type, expression, style)", "Converts an expression to another data type.", SqlFunctionCategory.Conversion),
+                Function("SUBSTRING", "SUBSTRING(expression, start, length)", "Returns part of a character or binary expression.", SqlFunctionCategory.String),
+                Function("LEN", "LEN(string_expression)", "Returns the number of characters.", SqlFunctionCategory.String),
+                Function("ROUND", "ROUND(numeric_expression, length)", "Rounds a numeric value.", SqlFunctionCategory.Math)
+            ],
+            [DatabaseType.Oracle] =
+            [
+                Function("COUNT", "COUNT(expression)", "Returns the number of items in a group.", SqlFunctionCategory.Aggregate),
+                Function("SUM", "SUM(expression)", "Returns the sum of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("AVG", "AVG(expression)", "Returns the average of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("MIN", "MIN(expression)", "Returns the minimum value.", SqlFunctionCategory.Aggregate),
+                Function("MAX", "MAX(expression)", "Returns the maximum value.", SqlFunctionCategory.Aggregate),
+                Function("SYSDATE", "SYSDATE", "Returns the current database date and time.", SqlFunctionCategory.DateTime),
+                Function("ADD_MONTHS", "ADD_MONTHS(date, integer)", "Adds months to a date.", SqlFunctionCategory.DateTime),
+                Function("MONTHS_BETWEEN", "MONTHS_BETWEEN(date1, date2)", "Returns the number of months between two dates.", SqlFunctionCategory.DateTime),
+                Function("NVL", "NVL(expr1, expr2)", "Replaces null with the specified value.", SqlFunctionCategory.NullHandling),
+                Function("NVL2", "NVL2(expr1, expr2, expr3)", "Returns one value when expr1 is not null and another when it is null.", SqlFunctionCategory.NullHandling),
+                Function("COALESCE", "COALESCE(expression, ...)", "Returns the first non-null expression.", SqlFunctionCategory.NullHandling),
+                Function("TO_DATE", "TO_DATE(char, fmt)", "Converts text to a date.", SqlFunctionCategory.Conversion),
+                Function("TO_CHAR", "TO_CHAR(value, fmt)", "Converts a value to text.", SqlFunctionCategory.Conversion),
+                Function("SUBSTR", "SUBSTR(char, position, substring_length)", "Returns part of a string.", SqlFunctionCategory.String),
+                Function("LENGTH", "LENGTH(char)", "Returns the length of a string.", SqlFunctionCategory.String),
+                Function("ROUND", "ROUND(value, integer)", "Rounds a number or date.", SqlFunctionCategory.Math)
+            ],
+            [DatabaseType.PostgresSql] =
+            [
+                Function("COUNT", "count(expression)", "Returns the number of items in a group.", SqlFunctionCategory.Aggregate),
+                Function("SUM", "sum(expression)", "Returns the sum of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("AVG", "avg(expression)", "Returns the average of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("MIN", "min(expression)", "Returns the minimum value.", SqlFunctionCategory.Aggregate),
+                Function("MAX", "max(expression)", "Returns the maximum value.", SqlFunctionCategory.Aggregate),
+                Function("NOW", "now()", "Returns the current transaction timestamp.", SqlFunctionCategory.DateTime),
+                Function("CURRENT_DATE", "current_date", "Returns the current date.", SqlFunctionCategory.DateTime),
+                Function("DATE_PART", "date_part(field, source)", "Returns a subfield from a date/time value.", SqlFunctionCategory.DateTime),
+                Function("DATE_TRUNC", "date_trunc(field, source)", "Truncates a date/time value.", SqlFunctionCategory.DateTime),
+                Function("COALESCE", "coalesce(expression, ...)", "Returns the first non-null expression.", SqlFunctionCategory.NullHandling),
+                Function("NULLIF", "nullif(value1, value2)", "Returns null if two values are equal.", SqlFunctionCategory.NullHandling),
+                Function("CAST", "cast(expression AS type)", "Converts an expression to another data type.", SqlFunctionCategory.Conversion),
+                Function("SUBSTRING", "substring(string, start, count)", "Returns part of a string.", SqlFunctionCategory.String),
+                Function("LENGTH", "length(string)", "Returns the length of a string.", SqlFunctionCategory.String),
+                Function("ROUND", "round(numeric, scale)", "Rounds a numeric value.", SqlFunctionCategory.Math)
+            ],
+            [DatabaseType.MySql] =
+            [
+                Function("COUNT", "COUNT(expr)", "Returns the number of items in a group.", SqlFunctionCategory.Aggregate),
+                Function("SUM", "SUM(expr)", "Returns the sum of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("AVG", "AVG(expr)", "Returns the average of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("MIN", "MIN(expr)", "Returns the minimum value.", SqlFunctionCategory.Aggregate),
+                Function("MAX", "MAX(expr)", "Returns the maximum value.", SqlFunctionCategory.Aggregate),
+                Function("NOW", "NOW()", "Returns the current date and time.", SqlFunctionCategory.DateTime),
+                Function("CURDATE", "CURDATE()", "Returns the current date.", SqlFunctionCategory.DateTime),
+                Function("DATE_ADD", "DATE_ADD(date, INTERVAL expr unit)", "Adds an interval to a date.", SqlFunctionCategory.DateTime),
+                Function("DATEDIFF", "DATEDIFF(expr1, expr2)", "Returns the number of days between two dates.", SqlFunctionCategory.DateTime),
+                Function("IFNULL", "IFNULL(expr1, expr2)", "Returns expr2 when expr1 is null.", SqlFunctionCategory.NullHandling),
+                Function("COALESCE", "COALESCE(expr, ...)", "Returns the first non-null expression.", SqlFunctionCategory.NullHandling),
+                Function("CAST", "CAST(expr AS type)", "Converts an expression to another data type.", SqlFunctionCategory.Conversion),
+                Function("SUBSTRING", "SUBSTRING(str, pos, len)", "Returns part of a string.", SqlFunctionCategory.String),
+                Function("CHAR_LENGTH", "CHAR_LENGTH(str)", "Returns the number of characters.", SqlFunctionCategory.String),
+                Function("ROUND", "ROUND(x, d)", "Rounds a numeric value.", SqlFunctionCategory.Math)
+            ],
+            [DatabaseType.SqLite] =
+            [
+                Function("COUNT", "count(expr)", "Returns the number of items in a group.", SqlFunctionCategory.Aggregate),
+                Function("SUM", "sum(expr)", "Returns the sum of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("AVG", "avg(expr)", "Returns the average of non-null values.", SqlFunctionCategory.Aggregate),
+                Function("MIN", "min(expr)", "Returns the minimum value.", SqlFunctionCategory.Aggregate),
+                Function("MAX", "max(expr)", "Returns the maximum value.", SqlFunctionCategory.Aggregate),
+                Function("DATE", "date(timestring, modifier, ...)", "Returns a date string.", SqlFunctionCategory.DateTime),
+                Function("TIME", "time(timestring, modifier, ...)", "Returns a time string.", SqlFunctionCategory.DateTime),
+                Function("DATETIME", "datetime(timestring, modifier, ...)", "Returns a date and time string.", SqlFunctionCategory.DateTime),
+                Function("STRFTIME", "strftime(format, timestring, modifier, ...)", "Formats a date/time value.", SqlFunctionCategory.DateTime),
+                Function("IFNULL", "ifnull(X, Y)", "Returns Y when X is null.", SqlFunctionCategory.NullHandling),
+                Function("COALESCE", "coalesce(X, ...)", "Returns the first non-null argument.", SqlFunctionCategory.NullHandling),
+                Function("CAST", "CAST(expr AS type)", "Converts an expression to another type.", SqlFunctionCategory.Conversion),
+                Function("SUBSTR", "substr(X, Y, Z)", "Returns part of a string.", SqlFunctionCategory.String),
+                Function("LENGTH", "length(X)", "Returns the length of a string or blob.", SqlFunctionCategory.String),
+                Function("ROUND", "round(X, Y)", "Rounds a numeric value.", SqlFunctionCategory.Math)
+            ]
+        };
+
+    public static IReadOnlyList<SqlFunctionDefinition> GetFunctions(DatabaseType databaseType)
+    {
+        return FunctionsByProvider.TryGetValue(databaseType, out var functions)
+            ? functions
+            : [];
+    }
+
+    public static SqlFunctionDefinition? FindFunction(DatabaseType databaseType, string name)
+    {
+        return GetFunctions(databaseType)
+            .FirstOrDefault(function => string.Equals(function.Name, name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static SqlFunctionDefinition Function(
+        string name,
+        string signature,
+        string description,
+        SqlFunctionCategory category)
+    {
+        var parameters = ParseParameters(signature, out var acceptsAdditionalArguments);
+        return new SqlFunctionDefinition(name, signature, description, InferReturnType(name, category), category, parameters, acceptsAdditionalArguments);
+    }
+
+    private static string InferReturnType(string name, SqlFunctionCategory category)
+    {
+        return name.ToUpperInvariant() switch
+        {
+            "COUNT" => "number",
+            "SUM" or "AVG" or "ROUND" => "number",
+            "DATEDIFF" or "MONTHS_BETWEEN" or "DATE_PART" or "LEN" or "LENGTH" or "CHAR_LENGTH" => "number",
+            "GETDATE" or "NOW" or "SYSDATE" or "DATETIME" or "DATEADD" or "ADD_MONTHS" or "DATE_TRUNC" => "date/time",
+            "CURRENT_DATE" or "CURDATE" or "DATE" or "TO_DATE" => "date",
+            "TIME" => "time",
+            "SUBSTRING" or "SUBSTR" or "TO_CHAR" or "STRFTIME" => "string",
+            "CAST" or "CONVERT" => "target type",
+            "MIN" or "MAX" or "ISNULL" or "IFNULL" or "NVL" or "NVL2" or "COALESCE" or "NULLIF" => "same as expression",
+            _ => category switch
+            {
+                SqlFunctionCategory.DateTime => "date/time",
+                SqlFunctionCategory.String => "string",
+                SqlFunctionCategory.Math or SqlFunctionCategory.Aggregate => "number",
+                SqlFunctionCategory.Conversion => "target type",
+                SqlFunctionCategory.NullHandling => "same as expression",
+                _ => "value"
+            }
+        };
+    }
+
+    private static IReadOnlyList<string> ParseParameters(string signature, out bool acceptsAdditionalArguments)
+    {
+        acceptsAdditionalArguments = false;
+        var openParenIndex = signature.IndexOf('(');
+        var closeParenIndex = signature.LastIndexOf(')');
+        if (openParenIndex < 0 || closeParenIndex <= openParenIndex)
+            return [];
+
+        var parameterList = signature[(openParenIndex + 1)..closeParenIndex].Trim();
+        if (string.IsNullOrWhiteSpace(parameterList))
+            return [];
+
+        var parameters = parameterList
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        if (parameters.Count > 0 && parameters[^1] == "...")
+        {
+            acceptsAdditionalArguments = true;
+            parameters.RemoveAt(parameters.Count - 1);
+        }
+        else if (parameters.Count > 0 && parameters[^1].EndsWith("...", StringComparison.Ordinal))
+        {
+            acceptsAdditionalArguments = true;
+            parameters[^1] = parameters[^1].Replace("...", string.Empty, StringComparison.Ordinal).Trim();
+            if (string.IsNullOrWhiteSpace(parameters[^1]))
+                parameters.RemoveAt(parameters.Count - 1);
+        }
+
+        return parameters;
+    }
+}

--- a/DataDeveloper/Services/SqlFunctionOverloadProvider.cs
+++ b/DataDeveloper/Services/SqlFunctionOverloadProvider.cs
@@ -1,0 +1,119 @@
+using System;
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using AvaloniaEdit.CodeCompletion;
+
+namespace DataDeveloper.Services;
+
+public sealed class SqlFunctionOverloadProvider : IOverloadProvider, INotifyPropertyChanged
+{
+    private readonly SqlFunctionDefinition _function;
+    private int _selectedIndex;
+    private int _argumentIndex;
+
+    public SqlFunctionOverloadProvider(SqlFunctionDefinition function, int argumentIndex)
+    {
+        _function = function;
+        _argumentIndex = Math.Max(0, argumentIndex);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public int SelectedIndex
+    {
+        get => _selectedIndex;
+        set
+        {
+            var safeValue = Math.Clamp(value, 0, Count - 1);
+            if (_selectedIndex == safeValue)
+                return;
+
+            _selectedIndex = safeValue;
+            RaiseCurrentPropertiesChanged();
+        }
+    }
+
+    public int Count => 1;
+
+    public string CurrentIndexText => string.Empty;
+
+    public object CurrentHeader => BuildHeader();
+
+    public object CurrentContent => _function.Description;
+
+    public void UpdateArgumentIndex(int argumentIndex)
+    {
+        var safeValue = Math.Max(0, argumentIndex);
+        if (_argumentIndex == safeValue)
+            return;
+
+        _argumentIndex = safeValue;
+        RaiseCurrentPropertiesChanged();
+    }
+
+    private object BuildHeader()
+    {
+        var monospace = TryGetFont("MonospaceFont");
+        var panel = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 0
+        };
+
+        panel.Children.Add(CreateText(_function.Name, Brushes.DeepSkyBlue, monospace));
+        panel.Children.Add(CreateText("(", Brushes.LightGray, monospace));
+
+        for (var index = 0; index < _function.Parameters.Count; index++)
+        {
+            if (index > 0)
+                panel.Children.Add(CreateText(", ", Brushes.LightGray, monospace));
+
+            var parameter = _function.Parameters[index];
+            var isActive = index == Math.Min(_argumentIndex, _function.Parameters.Count - 1);
+            panel.Children.Add(CreateText(parameter, isActive ? Brushes.Khaki : Brushes.White, monospace, isActive ? FontWeight.Bold : FontWeight.Normal));
+        }
+
+        if (_function.AcceptsAdditionalArguments && _function.Parameters.Count > 0)
+        {
+            panel.Children.Add(CreateText(", ...", _argumentIndex >= _function.Parameters.Count ? Brushes.Khaki : Brushes.LightGray, monospace));
+        }
+        else if (_function.AcceptsAdditionalArguments)
+        {
+            panel.Children.Add(CreateText("...", Brushes.Khaki, monospace));
+        }
+
+        panel.Children.Add(CreateText(")", Brushes.LightGray, monospace));
+        return panel;
+    }
+
+    private static TextBlock CreateText(string text, IBrush foreground, FontFamily? fontFamily, FontWeight fontWeight = FontWeight.Normal)
+    {
+        var textBlock = new TextBlock
+        {
+            Text = text,
+            Foreground = foreground,
+            FontWeight = fontWeight,
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        if (fontFamily is not null)
+            textBlock.FontFamily = fontFamily;
+
+        return textBlock;
+    }
+
+    private static FontFamily? TryGetFont(string key)
+    {
+        return Application.Current?.Resources[key] as FontFamily;
+    }
+
+    private void RaiseCurrentPropertiesChanged()
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentHeader)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentContent)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CurrentIndexText)));
+    }
+}

--- a/DataDeveloper/Views/TabQueryEditorView.axaml.cs
+++ b/DataDeveloper/Views/TabQueryEditorView.axaml.cs
@@ -31,6 +31,9 @@ public partial class TabQueryEditorView : UserControl
     private readonly TabTemplateSelector? _templateSelector;
     private readonly CompletionInteractionState _completionInteractionState = new();
     private CompletionWindow? _completionWindow;
+    private OverloadInsightWindow? _functionInsightWindow;
+    private SqlFunctionOverloadProvider? _functionOverloadProvider;
+    private string? _activeFunctionInsightName;
     private CompletionRequest? _pendingCompletionRequest;
 
     public TabQueryEditorView()
@@ -88,6 +91,7 @@ public partial class TabQueryEditorView : UserControl
 
     private void OnUnloaded(object? sender, RoutedEventArgs e)
     {
+        CloseFunctionInsight();
         GetMainWindowViewModel()?.ClearActiveEditor(SqlEditor);
     }
 
@@ -190,6 +194,11 @@ public partial class TabQueryEditorView : UserControl
 
     private async void TextAreaOnTextEntered(object? sender, TextInputEventArgs e)
     {
+        if (e.Text is "(" or ",")
+            ShowOrUpdateFunctionInsight();
+        else if (e.Text == ")")
+            CloseFunctionInsight();
+
         var shouldReopen = _completionInteractionState.HandleTextEntered(e.Text);
         if (shouldReopen)
         {
@@ -222,10 +231,21 @@ public partial class TabQueryEditorView : UserControl
             return;
 
         _completionWindow?.CompletionList.RequestInsertion(e);
+        if (e.Text == "(")
+            Dispatcher.UIThread.Post(ShowOrUpdateFunctionInsight, DispatcherPriority.Background);
     }
 
     private async void TextAreaOnKeyDown(object? sender, KeyEventArgs e)
     {
+        if (e.Key == Key.Space &&
+            e.KeyModifiers.HasFlag(KeyModifiers.Control) &&
+            e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            ShowOrUpdateFunctionInsight();
+            e.Handled = true;
+            return;
+        }
+
         if (e.Key == Key.Space && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {
             var request = SqlCompletionProvider.GetManualCompletionRequest(SqlEditor.Text ?? string.Empty, SqlEditor.CaretOffset);
@@ -261,22 +281,81 @@ public partial class TabQueryEditorView : UserControl
         if (rememberAsAutoRequest)
             _completionInteractionState.RememberAutoCompletion();
 
+        CloseFunctionInsight();
         _completionWindow?.Close();
-        _completionWindow = new CompletionWindow(SqlEditor.TextArea);
-        _completionWindow.StartOffset = SqlCompletionProvider.GetCompletionStartOffset(SqlEditor.Text ?? string.Empty, SqlEditor.CaretOffset);
+        var completionWindow = new CompletionWindow(SqlEditor.TextArea);
+        _completionWindow = completionWindow;
+        completionWindow.StartOffset = SqlCompletionProvider.GetCompletionStartOffset(SqlEditor.Text ?? string.Empty, SqlEditor.CaretOffset);
 
-        var data = _completionWindow.CompletionList.CompletionData;
+        var data = completionWindow.CompletionList.CompletionData;
         foreach (var completion in completions)
         {
             data.Add(completion);
         }
 
-        _completionWindow.Closed += (_, _) =>
+        completionWindow.Closed += (_, _) =>
         {
-            _completionWindow = null;
+            if (ReferenceEquals(_completionWindow, completionWindow))
+                _completionWindow = null;
+
             _completionInteractionState.ResetWhitespaceReopen();
+            Dispatcher.UIThread.Post(ShowOrUpdateFunctionInsight, DispatcherPriority.Background);
         };
-        _completionWindow.Show();
+        completionWindow.Show();
+    }
+
+    private void ShowOrUpdateFunctionInsight()
+    {
+        if (_viewModel is null)
+            return;
+
+        if (_completionWindow is not null)
+            return;
+
+        var context = SqlFunctionCallContextDetector.Detect(SqlEditor.Text ?? string.Empty, SqlEditor.CaretOffset);
+        if (context is null)
+        {
+            CloseFunctionInsight();
+            return;
+        }
+
+        var function = SqlFunctionCatalog.FindFunction(_viewModel.ConnectionSettings.DatabaseType, context.FunctionName);
+        if (function is null)
+        {
+            CloseFunctionInsight();
+            return;
+        }
+
+        if (_functionInsightWindow is not null &&
+            _functionOverloadProvider is not null &&
+            string.Equals(_activeFunctionInsightName, function.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            _functionOverloadProvider.UpdateArgumentIndex(context.ArgumentIndex);
+            return;
+        }
+
+        CloseFunctionInsight();
+        _functionOverloadProvider = new SqlFunctionOverloadProvider(function, context.ArgumentIndex);
+        _activeFunctionInsightName = function.Name;
+        _functionInsightWindow = new OverloadInsightWindow(SqlEditor.TextArea)
+        {
+            Provider = _functionOverloadProvider
+        };
+        _functionInsightWindow.Closed += (_, _) =>
+        {
+            _functionInsightWindow = null;
+            _functionOverloadProvider = null;
+            _activeFunctionInsightName = null;
+        };
+        _functionInsightWindow.Show();
+    }
+
+    private void CloseFunctionInsight()
+    {
+        _functionInsightWindow?.Close();
+        _functionInsightWindow = null;
+        _functionOverloadProvider = null;
+        _activeFunctionInsightName = null;
     }
 
     private void SqlEditorOnGotFocus(object? sender, GotFocusEventArgs e)

--- a/TODO-INSIGHT-WINDOW.md
+++ b/TODO-INSIGHT-WINDOW.md
@@ -1,0 +1,31 @@
+# Insight Window TODO
+
+## Function catalog
+
+- Expand the provider-specific function catalog beyond the initial common functions.
+- Add provider tests that assert representative functions for SQL Server, Oracle, PostgreSQL, MySQL, and SQLite.
+- Keep function metadata provider-specific when names, signatures, or behavior differ.
+
+## Return types
+
+- Replace broad inferred return types with explicit function metadata where possible.
+- Handle argument-dependent return types for functions such as `CAST`, `CONVERT`, `COALESCE`, `MIN`, `MAX`, `NVL`, and `IFNULL`.
+- Keep the completion row detail short, for example `returns date/time` or `returns target type`.
+
+## Overloads
+
+- Model multiple signatures per function.
+- Update the `IOverloadProvider` implementation to expose and navigate real overloads.
+- Add tests for overload selection and active argument highlighting.
+
+## Completion and insight window coordination
+
+- Revisit whether `CompletionWindow` and `InsightWindow` can be displayed at the same time without overlap.
+- Prefer public AvaloniaEdit APIs if a future version exposes positioning controls for insight windows.
+- Keep the current fallback behavior: close parameter insight while completion is open, then reopen it when completion closes and the caret is still inside a known function call.
+
+## Column and expression types
+
+- Keep showing real table column data types in completion rows using schema metadata.
+- Investigate type inference for CTE columns and projected expressions.
+- Avoid adding partial type inference unless it works consistently across supported providers.


### PR DESCRIPTION
## Summary
- add provider-specific SQL function completion entries with return-type details and description tooltips
- show AvaloniaEdit parameter insight for known function calls and update the active argument on commas
- include column data types in completion row descriptions using schema metadata
- document follow-up work in TODO-INSIGHT-WINDOW.md

## Tests
- dotnet test DataDeveloper.sln